### PR TITLE
Various fixes

### DIFF
--- a/inc/base.h
+++ b/inc/base.h
@@ -1,0 +1,15 @@
+#ifndef _BASE_H_
+#define _BASE_H_
+
+#include <limits.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef EDITING
+#define far __far
+#else
+#define far
+#endif
+
+#endif // _BASE_H_

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -3,7 +3,7 @@
 
 #ifndef __ASSEMBLER__
 
-#include <stdint.h>
+#include <base.h>
 
 typedef struct
 {

--- a/inc/ker.h
+++ b/inc/ker.h
@@ -3,15 +3,8 @@
 
 #ifndef __ASSEMBLER__
 
-#include <stdbool.h>
-
+#include <base.h>
 #include <fmt/zip.h>
-
-#ifndef EDITING
-#define far __far
-#else
-#define far
-#endif
 
 #define interrupt __attribute__((interrupt))
 

--- a/inc/sld.h
+++ b/inc/sld.h
@@ -3,8 +3,6 @@
 
 #ifndef __ASSEMBLER__
 
-#include <stdint.h>
-
 #include <gfx.h>
 #include <ker.h>
 

--- a/inc/vid.h
+++ b/inc/vid.h
@@ -3,8 +3,6 @@
 
 #ifndef __ASSEMBLER__
 
-#include <stdint.h>
-
 #include <gfx.h>
 
 #define VID_MODE_CGA_HIMONO 6 // 640x200x1

--- a/src/ker/start.c
+++ b/src/ker/start.c
@@ -1,5 +1,9 @@
+#include <string.h>
+
 #include <api/dos.h>
 #include <ker.h>
+
+extern char __sbss[], __ebss[];
 
 extern int
 Main(void);
@@ -25,6 +29,8 @@ _start(void)
 void
 KerEntry(void)
 {
+    memset(__sbss, 0, __ebss - __sbss);
+
     PitInitialize();
 
     int exitCode = Main();

--- a/src/ker/start.c
+++ b/src/ker/start.c
@@ -3,10 +3,10 @@
 #include <api/dos.h>
 #include <ker.h>
 
-extern char __sbss[], __ebss[];
+extern char __edata[], __sbss[], __ebss[];
 
 extern int
-Main(void);
+Main(ZIP_CDIR_END_HEADER *zip);
 
 extern void
 PitInitialize(void);
@@ -31,9 +31,15 @@ KerEntry(void)
 {
     memset(__sbss, 0, __ebss - __sbss);
 
+    ZIP_CDIR_END_HEADER *zip;
+    if (0 > KerLocateArchive(__edata, __sbss, &zip))
+    {
+        KerTerminate();
+    }
+
     PitInitialize();
 
-    int exitCode = Main();
+    int exitCode = Main(zip);
 
     PitDeinitialize();
 

--- a/src/ker/time.c
+++ b/src/ker/time.c
@@ -32,7 +32,7 @@ PlayerIsr(void);
 unsigned
 KerGetTicksFromMs(unsigned ms)
 {
-    unsigned ticks = ms * KER_DELAY_MS_MULTIPLIER;
+    uint32_t ticks = (uint32_t)ms * KER_DELAY_MS_MULTIPLIER;
     ticks /= (10000000UL * KER_DELAY_MS_MULTIPLIER) * KER_PIT_FREQ_DIVISOR /
              KER_PIT_INPUT_FREQ;
     return ticks;

--- a/src/main.c
+++ b/src/main.c
@@ -2,24 +2,16 @@
 #include <sld.h>
 #include <vid.h>
 
-extern char __edata[], __sbss[];
-
 const char SLIDES_TXT[] = "slides.txt";
 
 int
-Main(void)
+Main(ZIP_CDIR_END_HEADER *zip)
 {
     uint16_t oldMode = VidSetMode(VID_MODE_CGA_HIMONO);
     VidLoadFont();
 
-    ZIP_CDIR_END_HEADER *cdir;
-    if (0 > KerLocateArchive(__edata, __sbss, &cdir))
-    {
-        KerTerminate();
-    }
-
     ZIP_LOCAL_FILE_HEADER *lfh;
-    if (0 > KerSearchArchive(cdir, SLIDES_TXT, sizeof(SLIDES_TXT) - 1, &lfh))
+    if (0 > KerSearchArchive(zip, SLIDES_TXT, sizeof(SLIDES_TXT) - 1, &lfh))
     {
         KerTerminate();
     }
@@ -36,7 +28,7 @@ Main(void)
     while (0 < (length = SldLoadEntry(line, &entry)))
     {
         int status;
-        if (0 > (status = SldExecuteEntry(&entry, cdir)))
+        if (0 > (status = SldExecuteEntry(&entry, zip)))
         {
             KerTerminate();
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,3 @@
-#include <limits.h>
-
 #include <ker.h>
 #include <sld.h>
 #include <vid.h>

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,8 @@ Main(void)
 
         if (INT_MAX == status)
         {
-            if (0 > (length = SldFindLabel((const char *)data, entry.Content, &line)))
+            if (0 > (length = SldFindLabel((const char *)data, entry.Content,
+                                           &line)))
             {
                 KerTerminate();
             }


### PR DESCRIPTION
- fill `.bss` with zeros on startup - closes #25 
- utilize `uint32_t` for time arithmetic - closes #24 
- move common definitions to one header file
- move locating of the archive outside of main function