### PR TITLE
Inform the user that their environment is not supported

### DIFF
--- a/inc/api/dos.h
+++ b/inc/api/dos.h
@@ -3,6 +3,8 @@
 
 #include <dos.h>
 
+#include <base.h>
+
 inline void
 DosPutC(int c)
 {
@@ -15,10 +17,18 @@ DosPutS(const char *str)
     bdos(0x09, (unsigned)str, 0);
 }
 
+inline unsigned
+DosGetVersion(void)
+{
+    return bdos(0x30, 0, 0);
+}
+
 inline void
 DosExit(int code)
 {
     bdos(0x4C, 0, code);
+    while (1)
+        ;
 }
 
 #endif // _API_DOS_H

--- a/inc/api/dos.h
+++ b/inc/api/dos.h
@@ -5,6 +5,44 @@
 
 #include <base.h>
 
+#pragma pack(push, 1)
+typedef struct _DOS_PSP
+{
+    uint8_t  Int20H[2];
+    uint16_t MemoryEndSegment;
+    uint8_t  _Reserved1;
+    union {
+        uint8_t b[5];
+        struct
+        {
+            uint8_t  _Reserved1;
+            uint16_t ComSegmentSize;
+            uint8_t  _Reserved2[2];
+        } s;
+    } DispatcherCall;
+    far void *PreviousTerminate;
+    far void *PreviousBreak;
+    far void *PreviousCritical;
+    uint16_t  ParentPspSegment;
+    uint8_t   JobFileTable[20];
+    uint16_t  EnvironmentSegment;
+    far void *Int21HSsSp;
+    uint16_t  JobFileTableSize;
+    far uint8_t *JobFileTablePointer;
+    far uint8_t *PreviousPsp;
+    uint8_t      _Reserved2[4];
+    uint16_t     DosVersion;
+    uint8_t      _Reserved3[14];
+    uint8_t      FarCallEntry[3];
+    uint8_t      _Reserved4[2];
+    uint8_t      _Reserved5[7];
+    uint8_t      File1[16];
+    uint8_t      File2[20];
+    uint8_t      CommandLineLength;
+    uint8_t      CommandLine[127];
+} DOS_PSP;
+#pragma pack(pop)
+
 inline void
 DosPutC(int c)
 {

--- a/inc/fmt/exe.h
+++ b/inc/fmt/exe.h
@@ -1,0 +1,88 @@
+#ifndef _FMT_EXE_H_
+#define _FMT_EXE_H_
+
+#include <stdint.h>
+
+typedef uint8_t  UCHAR;
+typedef uint16_t USHORT;
+typedef int32_t  LONG;
+typedef uint32_t ULONG;
+
+#pragma pack(push, 1)
+typedef struct
+{                      // DOS .EXE header
+    USHORT e_magic;    // Magic number
+    USHORT e_cblp;     // Bytes on last page of file
+    USHORT e_cp;       // Pages in file
+    USHORT e_crlc;     // Relocations
+    USHORT e_cparhdr;  // Size of header in paragraphs
+    USHORT e_minalloc; // Minimum extra paragraphs needed
+    USHORT e_maxalloc; // Maximum extra paragraphs needed
+    USHORT e_ss;       // Initial (relative) SS value
+    USHORT e_sp;       // Initial SP value
+    USHORT e_csum;     // Checksum
+    USHORT e_ip;       // Initial IP value
+    USHORT e_cs;       // Initial (relative) CS value
+    USHORT e_lfarlc;   // File address of relocation table
+    USHORT e_ovno;     // Overlay number
+    USHORT e_res[4];   // Reserved words
+    USHORT e_oemid;    // OEM identifier (for e_oeminfo)
+    USHORT e_oeminfo;  // OEM information; e_oemid specific
+    USHORT e_res2[10]; // Reserved words
+    LONG   e_lfanew;   // File address of new exe header
+} EXE_DOS_HEADER;
+
+typedef struct
+{
+    USHORT Machine;
+    USHORT NumberOfSections;
+    ULONG  TimeDateStamp;
+    ULONG  PointerToSymbolTable;
+    ULONG  NumberOfSymbols;
+    USHORT SizeOfOptionalHeader;
+    USHORT Characteristics;
+} EXE_PE_FILE_HEADER;
+
+typedef struct
+{
+    //
+    // Standard fields.
+    //
+    USHORT Magic;
+    UCHAR  MajorLinkerVersion;
+    UCHAR  MinorLinkerVersion;
+    ULONG  SizeOfCode;
+    ULONG  SizeOfInitializedData;
+    ULONG  SizeOfUninitializedData;
+    ULONG  AddressOfEntryPoint;
+    ULONG  BaseOfCode;
+    ULONG  BaseOfData;
+    //
+    // NT additional fields.
+    //
+    ULONG  ImageBase;
+    ULONG  SectionAlignment;
+    ULONG  FileAlignment;
+    USHORT MajorOperatingSystemVersion;
+    USHORT MinorOperatingSystemVersion;
+    USHORT MajorImageVersion;
+    USHORT MinorImageVersion;
+    USHORT MajorSubsystemVersion;
+    USHORT MinorSubsystemVersion;
+    ULONG  Reserved1;
+    ULONG  SizeOfImage;
+    ULONG  SizeOfHeaders;
+    ULONG  CheckSum;
+    USHORT Subsystem;
+    USHORT DllCharacteristics;
+    ULONG  SizeOfStackReserve;
+    ULONG  SizeOfStackCommit;
+    ULONG  SizeOfHeapReserve;
+    ULONG  SizeOfHeapCommit;
+    ULONG  LoaderFlags;
+    ULONG  NumberOfRvaAndSizes;
+    //    IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+} EXE_PE_OPTIONAL_HEADER;
+#pragma pack(pop)
+
+#endif // _FMT_EXE_H_

--- a/inc/ker.h
+++ b/inc/ker.h
@@ -16,6 +16,12 @@ KerIsDosBox(void);
 extern bool
 KerIsDosMajor(uint8_t major);
 
+extern bool
+KerIsWindowsNt(void);
+
+extern far const char *
+KerGetEnvironmentVariable(const char *key);
+
 extern unsigned
 KerGetTicksFromMs(unsigned ms);
 

--- a/inc/ker.h
+++ b/inc/ker.h
@@ -22,6 +22,9 @@ KerIsWindowsNt(void);
 extern far const char *
 KerGetEnvironmentVariable(const char *key);
 
+extern uint16_t
+KerGetWindowsNtVersion(void);
+
 extern unsigned
 KerGetTicksFromMs(unsigned ms);
 

--- a/inc/ker.h
+++ b/inc/ker.h
@@ -13,6 +13,9 @@ typedef void(interrupt *isr)(void) far;
 extern bool
 KerIsDosBox(void);
 
+extern bool
+KerIsDosMajor(uint8_t major);
+
 extern unsigned
 KerGetTicksFromMs(unsigned ms);
 

--- a/src/ker/info.c
+++ b/src/ker/info.c
@@ -1,5 +1,4 @@
-#include <stdint.h>
-
+#include <api/dos.h>
 #include <ker.h>
 
 bool
@@ -12,4 +11,11 @@ KerIsDosBox(void)
             return false;
     }
     return true;
+}
+
+bool
+KerIsDosMajor(uint8_t major)
+{
+    uint8_t dosMajor = DosGetVersion() & 0xFF;
+    return (1 == major) ? (0 == dosMajor) : (major == dosMajor);
 }

--- a/src/ker/info.c
+++ b/src/ker/info.c
@@ -1,5 +1,9 @@
+#include <libi86/string.h>
+
 #include <api/dos.h>
 #include <ker.h>
+
+extern DOS_PSP *KerPsp;
 
 bool
 KerIsDosBox(void)
@@ -18,4 +22,44 @@ KerIsDosMajor(uint8_t major)
 {
     uint8_t dosMajor = DosGetVersion() & 0xFF;
     return (1 == major) ? (0 == dosMajor) : (major == dosMajor);
+}
+
+bool
+KerIsWindowsNt(void)
+{
+    // NTVDM claims to be DOS 5
+    if (!KerIsDosMajor(5))
+    {
+        return false; // It's not 5, so it's not NTVDM.
+    }
+
+    // Does it have %OS% environment variable?
+    far const char *os = KerGetEnvironmentVariable("OS");
+    if (0 == FP_SEG(os))
+    {
+        return false; // It's just a regular DOS 5.
+    }
+
+    // Does it claim to be Windows NT?
+    const char windowsNt[] = "Windows_NT";
+    return 0 == _fmemcmp(os, windowsNt, sizeof(windowsNt));
+}
+
+far const char *
+KerGetEnvironmentVariable(const char *key)
+{
+    far const char *env = MK_FP(KerPsp->EnvironmentSegment, 0);
+    size_t          keyLength = strlen(key);
+
+    while (*env)
+    {
+        if ((0 == _fmemcmp(key, env, keyLength)) && ('=' == env[keyLength]))
+        {
+            return env + keyLength + 1;
+        }
+
+        env += _fstrlen(env) + 1;
+    }
+
+    return MK_FP(0, 0);
 }

--- a/src/ker/start.c
+++ b/src/ker/start.c
@@ -14,6 +14,8 @@ PitInitialize(void);
 extern void
 PitDeinitialize(void);
 
+DOS_PSP *KerPsp;
+
 void
 _start(void) __attribute__((section(".startupA.0")));
 
@@ -30,6 +32,7 @@ void
 KerEntry(void)
 {
     memset(__sbss, 0, __ebss - __sbss);
+    KerPsp = (DOS_PSP *)0;
 
     ZIP_CDIR_END_HEADER *zip;
     if (0 > KerLocateArchive(__edata, __sbss, &zip))

--- a/src/main.c
+++ b/src/main.c
@@ -98,5 +98,5 @@ IsEnvironmentCompatible(void)
         return true;
     }
 
-    return false;
+    return 0x0600 > KerGetWindowsNtVersion();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -93,5 +93,10 @@ IsEnvironmentCompatible(void)
         return false;
     }
 
-    return true;
+    if (!KerIsWindowsNt())
+    {
+        return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
closes #27 
- DOS version detection
- Windows NT version detection
- configurable message on incompatible environment
- DOS 1.x is not compatible
- Windows NT 6+ is not compatible