### PR TITLE
Timing fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,23 @@ $(OBJ)/%.S.o: $(SRC)/%.S
 $(OBJ)/%.c.o: $(SRC)/%.c
 	$(CC) $(CFLAGS) -o $@ $<
 
-$(OBJ)/version.o: $(OBJ)/version.txt
-	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.startupA.1 $^ $@
+GIT_TAG     = $(shell git describe --abbrev=0)
+GIT_COMMITS = $(shell git rev-list $(GIT_TAG)..HEAD --count)
 
-$(OBJ)/version.txt:
+ifeq ($(GIT_COMMITS),0)
+VERSION = $(GIT_TAG)
+else
+VERSION = $(GIT_TAG)-$(GIT_COMMITS)
+endif
+
+$(OBJ)/version.o: $(OBJ)/version.txt .FORCE
+	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.startupA.1 $< $@
+
+$(OBJ)/version.txt: .FORCE
 	@mkdir -p $(OBJ)
-	/bin/echo -en "\rLavender $(shell git describe --tags $(GIT_COMMIT) --abbrev=0)-$(shell git rev-parse --short HEAD)\x1A" >$@
+	/bin/echo -en "\rLavender $(VERSION)\x1A" >$@
+
+ .FORCE:
 
 clean:
 	rm -rf $(BIN)

--- a/inc/fmt/spk.h
+++ b/inc/fmt/spk.h
@@ -1,0 +1,24 @@
+#ifndef _FMT_SPK_H_
+#define _FMT_SPK_H_
+
+#include <base.h>
+
+#pragma pack(push, 1)
+typedef struct
+{
+    uint8_t Format;
+    uint8_t TicksPerSecond;
+} SPK_HEADER;
+
+typedef struct
+{
+    uint8_t  Duration;
+    uint16_t Divisor;
+} SPK_NOTE3;
+#pragma pack(pop)
+
+#define SPK_FORMAT_NOTE3 3
+
+#define SPK_NOTE_DURATION_STOP 0
+
+#endif // _FMT_SPK_H_

--- a/src/ker/time.c
+++ b/src/ker/time.c
@@ -14,7 +14,7 @@
 
 #define SPKR_ENABLE 3
 
-static volatile unsigned counter = 0xFFFF;
+static volatile uint32_t counter;
 static isr               biosIsr;
 
 static volatile unsigned playerTicks = 0;
@@ -41,13 +41,10 @@ KerGetTicksFromMs(unsigned ms)
 void
 KerSleep(unsigned ticks)
 {
-    unsigned last = counter;
-    while (0 != ticks)
+    uint32_t until = counter + ticks;
+    while (counter != until)
     {
         asm("hlt");
-        if (counter == last)
-            continue;
-        ticks--;
     }
 }
 
@@ -87,7 +84,7 @@ PitInitChannel(unsigned channel, unsigned mode, unsigned divisor)
 void
 PitInitialize()
 {
-    counter = 0xFFFF;
+    counter = 0;
     biosIsr = KerInstallIsr(PitIsr, INT_PIT);
     PitInitChannel(0, PIT_MODE_RATE_GEN, KER_PIT_FREQ_DIVISOR);
 }

--- a/src/sld/ldentry.c
+++ b/src/sld/ldentry.c
@@ -24,6 +24,7 @@ SldLoadEntry(const char *line, SLD_ENTRY *out)
     if (SLD_TAG_PREFIX_LABEL == *cur)
     {
         out->Type = SLD_TYPE_LABEL;
+        out->Delay = 0;
         cur++;
         goto LoadContent;
     }


### PR DESCRIPTION
- set delay for labels to 0 (fixes #30)
- use 32-bit for time counter (fixes #31)
- change music file format to use one byte for duration (closes #33) and to finish with a note bearing duration of zero (fixes #32)
- shorten the version string (fixes #26)