### PR TITLE
Fix case-insensitive UTF-8 string comparison

### DIFF
--- a/src/ker/unicode.c
+++ b/src/ker/unicode.c
@@ -105,16 +105,16 @@ KerCompareUtf8IgnoreCase(const char *str1, const char *str2, unsigned length)
             return 1;
         }
 
-        if ((fold1[0] == fold2[0]) && (fold1[1] == fold2[1]))
+        if ((fold1[0] != fold2[0]) || (fold1[1] != fold2[1]))
         {
-            return 0;
+            return 1;
         }
 
-        str1++;
-        str2++;
+        str1 += length1;
+        str2 += length2;
     }
 
-    return 1;
+    return 0;
 }
 
 // Get case folding for Unicode code point

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,8 @@
+#include <api/bios.h>
 #include <api/dos.h>
 #include <ker.h>
 #include <sld.h>
 #include <vid.h>
-
-const char SLIDES_TXT[] = "slides.txt";
 
 static bool
 IsEnvironmentCompatible(void);
@@ -30,6 +29,7 @@ Main(ZIP_CDIR_END_HEADER *zip)
         }
 
         DosPutS((const char *)data);
+        BiosKeyboardGetKeystroke();
         return 1;
     }
 


### PR DESCRIPTION
fixes #35 
- fix conditions and iterators
- wait for key press after displaying the text about OS support status