### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is still work in progress, but I'm doing my best to separate working versio
 * displaying PBM bitmaps
 * drawing and filling rectangles
 * jumping between slides with key presses
+* inclusion of other scripts from within a script
 * PC speaker music playback
 * reporting the unsupported environment (DOS 1.x, Windows Vista and newer)
 
@@ -89,6 +90,19 @@ Stores the scan code in the *Accumulator*.
 ```
 
 Jumps to `<label>` if the *Accumulator* is equal to the `<value>`.
+
+### Script call
+```
+<delay> ! <script>
+- or -
+<delay> ! <script> <method> <crc32> <parameter> <data>
+```
+
+Calls a script file named `<script>` as plain text or using some encryption method.
+`<method>` is 0 for plain text, 1 for XOR48.
+`<crc32>` is hexadecimal.
+`<parameter>` is a decimal integer.
+`<data>` is up to 63 characters.
 
 ## Format of the PC speaker music file
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install nasm gcc-ia16-elf libi86-ia16-elf mingw-w64 zip -y
+    sudo apt install gcc-ia16-elf g++-mingw-w64-i686 libi86-ia16-elf zip -y
   displayName: 'Install additional tools'
 
 - script: make

--- a/com.ld
+++ b/com.ld
@@ -10,8 +10,8 @@ GROUP(-lc -lgcc -ldos-t -lm)
 
 MEMORY
   {
-    FILE : ORIGIN = 0x0100, LENGTH = 0xAF00 /* 44K */
-    REST : ORIGIN = 0xB000, LENGTH = 0x1000 /*  4K */
+    FILE : ORIGIN = 0x0100, LENGTH = 0xCF00 /* 52K */
+    REST : ORIGIN = 0xD000, LENGTH = 0x1000 /* 12K */
   }
 
 SECTIONS

--- a/src/sld/exentry.c
+++ b/src/sld/exentry.c
@@ -199,8 +199,7 @@ SldExecuteScriptCall(SLD_ENTRY *sld, ZIP_CDIR_END_HEADER *zip)
     }
 
     // Run if already decrypted
-    if (sld->ScriptCall.Crc32 ==
-        KerCalculateZipCrc((uint8_t *)data, lfh->UncompressedSize))
+    if (lfh->Crc32 == sld->ScriptCall.Crc32)
     {
         return SldRunScript(data, lfh->UncompressedSize, zip);
     }
@@ -216,6 +215,7 @@ SldExecuteScriptCall(SLD_ENTRY *sld, ZIP_CDIR_END_HEADER *zip)
     }
 
     CrgXor(data, data, lfh->UncompressedSize, (const uint8_t *)&key, 6);
+    lfh->Crc32 = KerCalculateZipCrc((uint8_t *)data, lfh->UncompressedSize);
     return SldRunScript(data, lfh->UncompressedSize, zip);
 }
 

--- a/src/sld/ldentry.c
+++ b/src/sld/ldentry.c
@@ -127,11 +127,10 @@ End:
         cur++;
     }
 
-    if (*cur == '\r')
+    while (('\r' == *cur) || ('\n' == *cur))
     {
         cur++;
     }
-    cur++;
 
     return cur - line;
 }


### PR DESCRIPTION
- fix CRC mismatch in `KerGetArchiveData` after decrypting a script file (fixes #49)
- fix handling of blank lines after the conditional jump (fixes #48)
- utilize whole 64K segment (closes #46)
- remove NASM and 64-bit MinGW-w64 from dependencies (closes #47)
- update docs