### PR TITLE
Add support for split keys

### DIFF
--- a/inc/crg.h
+++ b/inc/crg.h
@@ -30,6 +30,9 @@ CrgPromptKey(uint8_t *         key,
              CRG_KEY_VALIDATOR validate,
              void *            context);
 
+extern uint64_t
+CrgDecodeSplitKey(uint32_t longPart, uint32_t shortPart);
+
 #endif // __ASSEMBLER__
 
 #endif // _CRG_H_

--- a/inc/sld.h
+++ b/inc/sld.h
@@ -46,6 +46,7 @@ typedef enum
 
 #define SLD_PARAMETER_XOR48_INLINE 0
 #define SLD_PARAMETER_XOR48_PROMPT 1
+#define SLD_PARAMETER_XOR48_SPLIT  2
 
 typedef struct
 {

--- a/src/crg/module.mk
+++ b/src/crg/module.mk
@@ -1,2 +1,2 @@
 ASSOURCES := $(ASSOURCES) $(DIR)/messages.S
-CCSOURCES := $(CCSOURCES) $(DIR)/prompt.c $(DIR)/xor.c
+CCSOURCES := $(CCSOURCES) $(DIR)/prompt.c $(DIR)/splitkey.c $(DIR)/xor.c

--- a/src/crg/prompt.c
+++ b/src/crg/prompt.c
@@ -13,6 +13,12 @@ extern const char StrCrgEncryptedLine2[];
 extern const char StrCrgKeyInvalid[];
 
 static bool
+AllCharacters(const char *str, bool (*predicate)(int));
+
+static bool
+IsDecString(const char *str);
+
+static bool
 IsHexString(const char *str);
 
 bool
@@ -33,8 +39,19 @@ CrgPromptKey(uint8_t *         key,
         DlgDrawText(&frame, StrCrgEncryptedLine1, 0);
         DlgDrawText(&frame, StrCrgEncryptedLine2, 1);
 
-        int length = DlgInputText(&frame, buffer, keyLength * 2,
-                                  (16 == base) ? IsHexString : NULL, 3);
+        bool (*inputValidator)(const char *) = NULL;
+        switch (base)
+        {
+        case 10:
+            inputValidator = IsDecString;
+            break;
+        case 16:
+            inputValidator = IsHexString;
+            break;
+        }
+
+        int length =
+            DlgInputText(&frame, buffer, keyLength * 2, inputValidator, 3);
         if (0 == length)
         {
             return false;
@@ -67,7 +84,7 @@ CrgPromptKey(uint8_t *         key,
 }
 
 bool
-IsHexString(const char *str)
+AllCharacters(const char *str, bool (*predicate)(int))
 {
     if (!*str)
     {
@@ -76,7 +93,7 @@ IsHexString(const char *str)
 
     while (*str)
     {
-        if (!isxdigit(*str))
+        if (!predicate(*str))
         {
             return false;
         }
@@ -84,4 +101,16 @@ IsHexString(const char *str)
     }
 
     return true;
+}
+
+bool
+IsHexString(const char *str)
+{
+    return AllCharacters(str, (bool (*)(int))isxdigit);
+}
+
+bool
+IsDecString(const char *str)
+{
+    return AllCharacters(str, (bool (*)(int))isdigit);
 }

--- a/src/crg/splitkey.c
+++ b/src/crg/splitkey.c
@@ -1,0 +1,50 @@
+#include <crg.h>
+
+#define UINTN_MAX(n) ((1UL << n) - 1)
+
+#define KEY_LOW_PART       0
+#define KEY_LOW_PART_MASK  UINTN_MAX(24)
+#define KEY_HIGH_PART      24
+#define KEY_HIGH_PART_MASK UINTN_MAX(24)
+
+#define LONGPART_HIGH_ROTATION      30
+#define LONGPART_HIGH_ROTATION_MASK UINTN_MAX(2)
+#define LONGPART_HIGH_PART          24
+#define LONGPART_HIGH_PART_MASK     UINTN_MAX(6)
+#define LONGPART_LOW_PART           0
+#define LONGPART_LOW_PART_MASK      UINTN_MAX(24)
+
+#define SHORTPART_LOW_ROTATION      18
+#define SHORTPART_LOW_ROTATION_MASK UINTN_MAX(2)
+#define SHORTPART_HIGH_PART         0
+#define SHORTPART_HIGH_PART_MASK    UINTN_MAX(18)
+#define SHORTPART_HIGH_PART_SHIFT   6
+
+static const unsigned KeyRotationOffsets[] = {3, 7, 13, 19};
+
+static uint32_t
+RotateRight24(uint32_t n, unsigned c)
+{
+    return (n >> c | n << (24 - c)) & UINTN_MAX(24);
+}
+
+uint64_t
+CrgDecodeSplitKey(uint32_t longPart, uint32_t shortPart)
+{
+    uint32_t lowPart = (longPart >> LONGPART_LOW_PART) & LONGPART_LOW_PART_MASK;
+    uint32_t highPart =
+        (((shortPart >> SHORTPART_HIGH_PART) & SHORTPART_HIGH_PART_MASK)
+         << SHORTPART_HIGH_PART_SHIFT) |
+        ((longPart >> LONGPART_HIGH_PART) & LONGPART_HIGH_PART_MASK);
+
+    unsigned lowRotation =
+        (shortPart >> SHORTPART_LOW_ROTATION) & SHORTPART_LOW_ROTATION_MASK;
+    unsigned highRotation =
+        (longPart >> LONGPART_HIGH_ROTATION) & LONGPART_HIGH_ROTATION_MASK;
+
+    lowPart = RotateRight24(lowPart, KeyRotationOffsets[lowRotation]);
+    highPart = RotateRight24(highPart, KeyRotationOffsets[highRotation]);
+
+    return (((uint64_t)highPart & KEY_HIGH_PART_MASK) << KEY_HIGH_PART) |
+           (((uint64_t)lowPart & KEY_LOW_PART_MASK) << KEY_LOW_PART);
+}


### PR DESCRIPTION
- validate input for decimal key parts
- decode split XOR48 keys
- allow for split keys with long part stored inside the script (closes #14)