### PR TITLE
Fix floppy drive access errors

### DIFF
--- a/inc/api/bios.h
+++ b/inc/api/bios.h
@@ -1,10 +1,31 @@
 #ifndef _API_BIOS_H
 #define _API_BIOS_H
 
+#include <assert.h>
 #include <i86.h>
 
 #include <fmt/edid.h>
 #include <ker.h>
+
+#pragma pack(push, 1)
+typedef struct
+{
+    bool     FloppyDisk : 1;
+    bool     X87 : 1;
+    unsigned OnBoardMemory : 2;
+    unsigned InitialVideoMode : 2;
+    unsigned FloppyDrives : 2;
+    bool     NoDma : 1;
+    unsigned SerialPorts : 3;
+    bool     GamePort : 1;
+    bool     SerialPrinter : 1;
+    unsigned ParallelPorts : 2;
+} BIOS_EQUIPMENT;
+
+static_assert(sizeof(uint16_t) == sizeof(BIOS_EQUIPMENT),
+              "BIOS equipment list size doesn't match specification");
+
+#pragma pack(pop)
 
 inline uint16_t
 BiosKeyboardGetKeystroke(void)
@@ -58,6 +79,14 @@ BiosVideoVbeDcCapabilities()
 {
     unsigned short ax;
     asm volatile("int $0x10" : "=a"(ax) : "a"(0x4F15), "b"(0));
+    return ax;
+}
+
+inline short
+BiosGetEquipmentList(void)
+{
+    unsigned short ax;
+    asm volatile("int $0x11" : "=a"(ax));
     return ax;
 }
 

--- a/inc/fmt/fat.h
+++ b/inc/fmt/fat.h
@@ -1,9 +1,19 @@
-#ifndef _FMT_BOOTSECT_H
-#define _FMT_BOOTSECT_H
+#ifndef _FMT_FAT_H_
+#define _FMT_FAT_H_
 
 #include <assert.h>
 
 #include <base.h>
+
+#define FAT_ATTRIBUTE_READ_ONLY 0x01
+#define FAT_ATTRIBUTE_HIDDEN    0x02
+#define FAT_ATTRIBUTE_SYSTEM    0x04
+#define FAT_ATTRIBUTE_VOLUME_ID 0x08
+#define FAT_ATTRIBUTE_DIRECTORY 0x10
+#define FAT_ATTRIBUTE_ARCHIVE   0x20
+#define FAT_ATTRIBUTE_LFN                                                      \
+    (FAT_ATTRIBUTE_READ_ONLY | FAT_ATTRIBUTE_HIDDEN | FAT_ATTRIBUTE_SYSTEM |   \
+     FAT_ATTRIBUTE_VOLUME_ID)
 
 #pragma pack(push, 1)
 
@@ -116,6 +126,45 @@ typedef struct
 static_assert(79 == sizeof(BPB_DOS71_FULL),
               "DOS 7.1 full BPB size doesn't match specification");
 
+typedef struct
+{
+    unsigned DoubleSecond : 5;
+    unsigned Minute : 6;
+    unsigned Hour : 5;
+} FAT_TIME;
+
+static_assert(sizeof(uint16_t) == sizeof(FAT_TIME),
+              "FAT time struct size doesn't match specification");
+
+typedef struct
+{
+    unsigned Day : 5;
+    unsigned Month : 4;
+    unsigned Year : 7;
+} FAT_DATE;
+
+static_assert(sizeof(uint16_t) == sizeof(FAT_DATE),
+              "FAT date struct size doesn't match specification");
+
+typedef struct
+{
+    char     FileName[11];
+    uint8_t  Attributes;
+    uint8_t  Reserved;
+    uint8_t  CreationCentiseconds;
+    FAT_TIME CreationTime;
+    FAT_DATE CreationDate;
+    FAT_DATE AccessDate;
+    uint16_t FirstClusterHigh;
+    FAT_TIME ModificationTime;
+    FAT_DATE ModificationDate;
+    uint16_t FirstClusterLow;
+    uint32_t Size;
+} FAT_DIRECTORY_ENTRY;
+
+static_assert(32 == sizeof(FAT_DIRECTORY_ENTRY),
+              "FAT directory entry size doesn't match specification");
+
 #pragma pack(pop)
 
-#endif // _FMT_BOOTSECT_H
+#endif // _FMT_FAT_H_

--- a/inc/ker.h
+++ b/inc/ker.h
@@ -31,6 +31,9 @@ KerGetEnvironmentVariable(const char *key);
 extern uint16_t
 KerGetWindowsNtVersion(void);
 
+extern int
+KerGetFloppyDriveCount(void);
+
 // Get volume identification information
 // Returns 0 on success, negative on error
 extern int

--- a/src/ker/info.c
+++ b/src/ker/info.c
@@ -2,6 +2,7 @@
 #include <libi86/string.h>
 #include <unistd.h>
 
+#include <api/bios.h>
 #include <api/dos.h>
 #include <fmt/bootsect.h>
 #include <fmt/exe.h>
@@ -115,6 +116,14 @@ KerGetEnvironmentVariable(const char *key)
     }
 
     return MK_FP(0, 0);
+}
+
+int
+KerGetFloppyDriveCount(void)
+{
+    BIOS_EQUIPMENT equipment;
+    *(short *)&equipment = BiosGetEquipmentList();
+    return equipment.FloppyDisk ? (equipment.FloppyDrives + 1) : 0;
 }
 
 int

--- a/src/ker/info.c
+++ b/src/ker/info.c
@@ -4,8 +4,8 @@
 
 #include <api/bios.h>
 #include <api/dos.h>
-#include <fmt/bootsect.h>
 #include <fmt/exe.h>
+#include <fmt/fat.h>
 #include <ker.h>
 
 extern DOS_PSP *KerPsp;
@@ -129,27 +129,32 @@ KerGetFloppyDriveCount(void)
 int
 KerGetVolumeInfo(uint8_t drive, KER_VOLUME_INFO *out)
 {
-    BOOT_SECTOR bs;
-    if (0 != DosReadDiskAbsolute(drive, 1, 0, (char *)&bs))
+    union {
+        char                Bytes[512];
+        BOOT_SECTOR         Boot;
+        FAT_DIRECTORY_ENTRY Root[512 / sizeof(FAT_DIRECTORY_ENTRY)];
+    } sector;
+
+    if (0 != DosReadDiskAbsolute(drive, 1, 0, sector.Bytes))
     {
         ERR(KER_DISK_ACCESS);
     }
 
-    if (0xAA55U != bs.Magic)
+    if (0xAA55U != sector.Boot.Magic)
     {
         ERR(KER_UNSUPPORTED);
     }
 
     int offset, size;
-    switch ((uint8_t)bs.Jump[0])
+    switch ((uint8_t)sector.Boot.Jump[0])
     {
     case 0xEB: // JMP rel8
-        offset = *(int8_t *)(bs.Jump + 1);
-        size = offset - (sizeof(bs.OemString) + 1);
+        offset = *(int8_t *)(sector.Boot.Jump + 1);
+        size = offset - (sizeof(sector.Boot.OemString) + 1);
         break;
     case 0xE9: // JMP rel16
-        offset = *(int16_t *)(bs.Jump + 1);
-        size = offset - sizeof(bs.OemString);
+        offset = *(int16_t *)(sector.Boot.Jump + 1);
+        size = offset - sizeof(sector.Boot.OemString);
         break;
     default:
         ERR(KER_UNSUPPORTED);
@@ -165,25 +170,25 @@ KerGetVolumeInfo(uint8_t drive, KER_VOLUME_INFO *out)
         out->Label[0] = 0;
         break;
     case sizeof(BPB_DOS34): {
-        BPB_DOS34 *bpb = (BPB_DOS34 *)bs.Payload;
+        BPB_DOS34 *bpb = (BPB_DOS34 *)sector.Boot.Payload;
         out->SerialNumber = bpb->SerialNumber;
         out->Label[0] = 0;
         break;
     }
     case sizeof(BPB_DOS40): {
-        BPB_DOS40 *bpb = (BPB_DOS40 *)bs.Payload;
+        BPB_DOS40 *bpb = (BPB_DOS40 *)sector.Boot.Payload;
         out->SerialNumber = bpb->Bpb34.SerialNumber;
         CopyVolumeLabel(out->Label, bpb->Label);
         break;
     }
     case sizeof(BPB_DOS71): {
-        BPB_DOS71 *bpb = (BPB_DOS71 *)bs.Payload;
+        BPB_DOS71 *bpb = (BPB_DOS71 *)sector.Boot.Payload;
         out->SerialNumber = bpb->SerialNumber;
         out->Label[0] = 0;
         break;
     }
     case sizeof(BPB_DOS71_FULL): {
-        BPB_DOS71_FULL *bpb = (BPB_DOS71_FULL *)bs.Payload;
+        BPB_DOS71_FULL *bpb = (BPB_DOS71_FULL *)sector.Boot.Payload;
         out->SerialNumber = bpb->Bpb71.SerialNumber;
         CopyVolumeLabel(out->Label, bpb->Label);
         break;
@@ -192,6 +197,29 @@ KerGetVolumeInfo(uint8_t drive, KER_VOLUME_INFO *out)
         ERR(KER_UNSUPPORTED);
     }
 
+    BPB_DOS20 *bpb = (BPB_DOS20 *)sector.Boot.Payload;
+    uint16_t   rootDirEntries = bpb->RootEntries;
+    uint16_t rootDirSectors = ((rootDirEntries * sizeof(FAT_DIRECTORY_ENTRY)) +
+                               (bpb->BytesPerSector - 1)) /
+                              bpb->BytesPerSector;
+    uint16_t firstDataSector = bpb->ReservedSectors +
+                               (bpb->Fats * bpb->SectorsPerFat) +
+                               rootDirSectors;
+    uint16_t firstRootDirSector = firstDataSector - rootDirSectors;
+
+    if (0 != DosReadDiskAbsolute(drive, 1, firstRootDirSector, sector.Bytes))
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < (sizeof(sector) / sizeof(FAT_DIRECTORY_ENTRY)); i++)
+    {
+        if (FAT_ATTRIBUTE_VOLUME_ID != sector.Root[i].Attributes)
+            continue;
+
+        CopyVolumeLabel(out->Label, sector.Root[i].FileName);
+        break;
+    }
     return 0;
 }
 

--- a/src/sld/exentry.c
+++ b/src/sld/exentry.c
@@ -258,8 +258,12 @@ SldExecuteScriptCall(SLD_ENTRY *sld, ZIP_CDIR_END_HEADER *zip)
     }
     case SLD_PARAMETER_XOR48_DISKID: {
         KER_VOLUME_INFO volume = {{0}, 0};
-        uint8_t         drive;
-        for (drive = 0; drive < 2; drive++)
+        int             maxDrives = KerGetFloppyDriveCount();
+        if (2 < maxDrives)
+            maxDrives = 2;
+
+        uint8_t drive;
+        for (drive = 0; drive < maxDrives; drive++)
         {
             if (0 > KerGetVolumeInfo(drive, &volume))
                 continue;
@@ -268,7 +272,7 @@ SldExecuteScriptCall(SLD_ENTRY *sld, ZIP_CDIR_END_HEADER *zip)
                 break;
         }
 
-        if (2 == drive)
+        if (maxDrives == drive)
         {
             char sn[10];
             if (!SldPromptVolumeSerialNumber(sn))


### PR DESCRIPTION
- check for the number of floppy drives before reading (fixes #65)
- look for the volume label in the root directory (fixes #64)