### PR TITLE
Allow loading assets from disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifndef LAV_LANG
 LAV_LANG = ENU
 endif
 
-CFLAGS  = -c -march=i8088 -Os -Wall -Werror -Iinc/
+CFLAGS  = -c -march=i8088 -Os -Wall -Werror -Iinc/ -DZIP_PIGGYBACK
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu/gcc/ia16-elf/6.3.0 -L/usr/ia16-elf/lib -T com.ld -li86 --nmagic
 
 BIN     = bin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,11 @@ steps:
 - script: |
     LAV_LANG=PLK make
     mkdir bin/PLK
-    mv bin/*.com bin/PLK/
+    mv bin/*.exe bin/PLK/
     rm obj/resource.*
     LAV_LANG=CSY make
     mkdir bin/CSY
-    mv bin/*.com bin/CSY/
+    mv bin/*.exe bin/CSY/
     rm obj/resource.*
     make
   displayName: 'Build Lavender'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,20 @@ pr:
 pool:
   vmImage: ubuntu-latest
 
+parameters:
+- name: targets
+  type: object
+  default:
+    - dospc-com
+    - dospc-exe
+
+- name: languages
+  type: object
+  default:
+    - CSY
+    - ENU
+    - PLK
+
 steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
@@ -16,17 +30,10 @@ steps:
     sudo apt install gcc-ia16-elf g++-mingw-w64-i686 libi86-ia16-elf zip -y
   displayName: 'Install additional tools'
 
-- script: |
-    LAV_LANG=PLK make
-    mkdir bin/PLK
-    mv bin/*.exe bin/PLK/
-    rm obj/resource.*
-    LAV_LANG=CSY make
-    mkdir bin/CSY
-    mv bin/*.exe bin/CSY/
-    rm obj/resource.*
-    make
-  displayName: 'Build Lavender'
+- ${{ each target in parameters.targets }}:
+  - ${{ each language in parameters.languages }}:
+    - script: LAV_TARGET=${{ target }} LAV_LANG=${{ language }} make
+      displayName: 'Build for ${{ target }} (${{ language }})'
 
 - script: make tools
   displayName: 'Build tools'

--- a/inc/base.h
+++ b/inc/base.h
@@ -2,10 +2,10 @@
 #define _BASE_H_
 
 #include <limits.h>
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #ifndef EDITING
 #define far __far

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -159,6 +159,10 @@ zip_search(zip_cdir_end_header *cdir, const char *name, uint16_t length);
 extern char *
 zip_get_data(zip_local_file_header *lfh, bool ignore_crc);
 
+// Get ZIP file size
+extern uint32_t
+zip_get_size(zip_local_file_header *lfh);
+
 // Calculate ZIP-compatible CRC-32 checksum of a buffer
 // Returns checksum value
 extern uint32_t

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -153,10 +153,14 @@ typedef struct
 extern off_t
 zip_search(off_t ocdir, const char *name, uint16_t length);
 
-// Locate ZIP file data
+// Retrieve ZIP file data
 // Returns NULL on error
 extern char *
 zip_get_data(off_t olfh);
+
+// Dispose ZIP file data
+extern void
+zip_free_data(char *data);
 
 // Get ZIP file size
 extern uint32_t

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -149,7 +149,11 @@ typedef struct
     char     unicode_name[];
 } zip_extra_unicode_path_field;
 
+#ifdef ZIP_PIGGYBACK
 typedef zip_cdir_end_header *zip_archive;
+#else
+typedef const char *zip_archive;
+#endif
 
 // Set working archive
 // archive is either a pointer to file name, or to address of ZIP central

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -149,9 +149,17 @@ typedef struct
     char     unicode_name[];
 } zip_extra_unicode_path_field;
 
+typedef zip_cdir_end_header *zip_archive;
+
+// Set working archive
+// archive is either a pointer to file name, or to address of ZIP central
+// directory
+extern bool
+zip_open(zip_archive archive);
+
 // Locate ZIP local file header structure
 extern off_t
-zip_search(off_t ocdir, const char *name, uint16_t length);
+zip_search(const char *name, uint16_t length);
 
 // Retrieve ZIP file data
 // Returns NULL on error

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -156,7 +156,7 @@ zip_search(off_t ocdir, const char *name, uint16_t length);
 // Locate ZIP file data
 // Returns NULL on error
 extern char *
-zip_get_data(off_t olfh, bool ignore_crc);
+zip_get_data(off_t olfh);
 
 // Get ZIP file size
 extern uint32_t

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -150,18 +150,17 @@ typedef struct
 } zip_extra_unicode_path_field;
 
 // Locate ZIP local file header structure
-// Returns NULL on error
-extern zip_local_file_header *
-zip_search(zip_cdir_end_header *cdir, const char *name, uint16_t length);
+extern off_t
+zip_search(off_t ocdir, const char *name, uint16_t length);
 
 // Locate ZIP file data
 // Returns NULL on error
 extern char *
-zip_get_data(zip_local_file_header *lfh, bool ignore_crc);
+zip_get_data(off_t olfh, bool ignore_crc);
 
 // Get ZIP file size
 extern uint32_t
-zip_get_size(zip_local_file_header *lfh);
+zip_get_size(off_t olfh);
 
 // Calculate ZIP-compatible CRC-32 checksum of a buffer
 // Returns checksum value

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -16,7 +16,7 @@ DEFINE_HANDLE(htimer);
 typedef void (*pal_timer_callback)(void *context);
 
 extern void
-pal_initialize(void);
+pal_initialize(int argc, char *argv[]);
 
 extern void
 pal_cleanup(void);

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -81,6 +81,12 @@ zip_get_data(off_t olfh)
     return buffer;
 }
 
+void
+zip_free_data(char *data)
+{
+    return;
+}
+
 uint32_t
 zip_get_size(off_t olfh)
 {

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -52,7 +52,7 @@ zip_search(off_t ocdir, const char *name, uint16_t length)
 }
 
 char *
-zip_get_data(off_t olfh, bool ignore_crc)
+zip_get_data(off_t olfh)
 {
     const zip_local_file_header *lfh =
         (const zip_local_file_header *)(intptr_t)olfh;
@@ -71,9 +71,8 @@ zip_get_data(off_t olfh, bool ignore_crc)
     }
 
     char *buffer = (char *)(lfh + 1) + lfh->name_length + lfh->extra_length;
-    if (!ignore_crc &&
-        (zip_calculate_crc((uint8_t *)buffer, lfh->uncompressed_size) !=
-         lfh->crc32))
+    if (zip_calculate_crc((uint8_t *)buffer, lfh->uncompressed_size) !=
+        lfh->crc32)
     {
         errno = EIO;
         return NULL;

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -78,6 +78,12 @@ zip_get_data(zip_local_file_header *lfh, bool ignore_crc)
     return buffer;
 }
 
+uint32_t
+zip_get_size(zip_local_file_header *lfh)
+{
+    return lfh->compressed_size;
+}
+
 // Check if ZIP Central Directory File Header matches provided name
 // Returns 0 on match, 1 on no match, negative on error
 int

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,7 @@ main(int argc, char *argv[])
 {
     int status = EXIT_SUCCESS;
 
-    pal_initialize();
+    pal_initialize(argc, argv);
 
     sld_context *script = sld_create_context("slides.txt", NULL);
     if (NULL == script)

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -284,6 +284,14 @@ pal_initialize(void)
 void
 pal_cleanup(void)
 {
+    for (int i = 0; i < MAX_OPEN_ASSETS; ++i)
+    {
+        if (NULL != _assets[i].data)
+        {
+            zip_free_data(_assets[i].data);
+        }
+    }
+
     gfx_cleanup();
 
     _dos_setvect(INT_PIT, _bios_isr);
@@ -378,7 +386,12 @@ pal_close_asset(hasset asset)
     }
 
     ptr->inzip = -1;
-    ptr->data = NULL;
+
+    if (NULL != ptr->data)
+    {
+        zip_free_data(ptr->data);
+        ptr->data = NULL;
+    }
     return true;
 }
 

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -359,7 +359,7 @@ pal_close_asset(hasset asset)
     {
         ptr->zip_header->crc32 =
             zip_calculate_crc((uint8_t *)zip_get_data(ptr->zip_header, true),
-                              ptr->zip_header->compressed_size);
+                              zip_get_size(ptr->zip_header));
     }
 
     ptr->zip_header = NULL;
@@ -389,7 +389,7 @@ pal_get_asset_size(hasset asset)
         return -1;
     }
 
-    return ptr->zip_header->compressed_size;
+    return zip_get_size(ptr->zip_header);
 }
 
 static void

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -124,8 +124,7 @@ _pit_isr(void)
 static void
 _die_errno(void)
 {
-    char msg[80];
-    pal_load_string(IDS_ERROR, msg, sizeof(msg));
+    char msg[80] = "errno ";
     itoa(errno, msg + strlen(msg), 10);
     msg[strlen(msg)] = '$';
     dos_puts(msg);
@@ -242,6 +241,7 @@ pal_initialize(void)
         msg[strlen(msg)] = '$';
         dos_puts(msg);
 
+        dos_puts("\r\n$");
         _die_errno();
         dos_exit(1);
     }

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -394,7 +394,7 @@ pal_get_asset_data(hasset asset)
 
     if (NULL == ptr->data)
     {
-        ptr->data = zip_get_data(ptr->inzip, false);
+        ptr->data = zip_get_data(ptr->inzip);
     }
 
     return ptr->data;

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -32,6 +32,7 @@ typedef struct
 {
     off_t inzip;
     int   flags;
+    char *data;
 } _asset;
 
 #define DELAY_MS_MULTIPLIER 100ULL
@@ -269,6 +270,7 @@ pal_initialize(void)
     {
         _assets[i].inzip = -1;
         _assets[i].flags = 0;
+        _assets[i].data = NULL;
     }
 
     if (!gfx_initialize())
@@ -376,6 +378,7 @@ pal_close_asset(hasset asset)
     }
 
     ptr->inzip = -1;
+    ptr->data = NULL;
     return true;
 }
 
@@ -389,7 +392,12 @@ pal_get_asset_data(hasset asset)
         return NULL;
     }
 
-    return zip_get_data(ptr->inzip, O_RDWR == (ptr->flags & O_ACCMODE));
+    if (NULL == ptr->data)
+    {
+        ptr->data = zip_get_data(ptr->inzip, false);
+    }
+
+    return ptr->data;
 }
 
 int


### PR DESCRIPTION
- make ZIP API use opaque data types
- add open/dispose pattern to ZIP data
- add support for loading asset data from disk, from ZIP appended to the executable
- build COM (in-memory archive) and EXE (loaded archive)

Closes #75, closes #76 