### PR TITLE
Detect DOS 2.x before trying to open ZIP

### DIFF
--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -209,13 +209,6 @@ static bool
 _is_compatible(void)
 {
     // We're using DOS 2.0+ API here, and we can't run on Vista and above.
-#ifndef ZIP_PIGGYBACK
-    if (_is_dos(2))
-    {
-        return false;
-    }
-#endif
-
     return !_is_dos(1) && (!_is_winnt() || (0x0600 > _get_winnt_version()));
 }
 
@@ -244,6 +237,12 @@ pal_initialize(int argc, char *argv[])
 
     if (!zip_open(cdir))
 #else
+    if (_is_dos(2))
+    {
+        dos_puts("Lavender needs at least DOS 3.0 in EXE mode.$");
+        dos_exit(1);
+    }
+
     if (!zip_open(argv[0]))
 #endif
     {

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -132,6 +132,15 @@ _die_errno(void)
     dos_puts(msg);
 }
 
+static void
+_die_incompatible(void)
+{
+    char msg[80];
+    pal_load_string(IDS_UNSUPPENV, msg, sizeof(msg));
+    msg[strlen(msg)] = '$';
+    dos_puts(msg);
+}
+
 static bool
 _is_dos(uint8_t major)
 {
@@ -239,7 +248,8 @@ pal_initialize(int argc, char *argv[])
 #else
     if (_is_dos(2))
     {
-        dos_puts("Lavender needs at least DOS 3.0 in EXE mode.$");
+        dos_puts("EXE \x1A DOS 3+\r\n$");
+        _die_incompatible();
         dos_exit(1);
     }
 
@@ -270,7 +280,7 @@ pal_initialize(int argc, char *argv[])
         hasset support = pal_open_asset("support.txt", O_RDONLY);
         if (NULL == support)
         {
-            dos_puts("Lavender cannot run in your environment.$");
+            _die_incompatible();
             dos_exit(1);
         }
 

--- a/src/resource.CSY.rc
+++ b/src/resource.CSY.rc
@@ -5,6 +5,7 @@ LANGUAGE LCID_CSY, 0x1
 {
     IDS_ERROR, "CHYBA: "
     IDS_NOARCHIVE, "Archiv nenalezen"
+    IDS_UNSUPPENV, "Lavender nemuze bezet ve vasem prostredi."
 
     IDS_ENTERDSN, "Zadejte sériové číslo disku"
     IDS_ENTERDSN_DESC, "Zadejte prosím sériové číslo\npřipojené k disketě programu."

--- a/src/resource.ENU.rc
+++ b/src/resource.ENU.rc
@@ -5,6 +5,7 @@ LANGUAGE LCID_ENU, 0x1
 {
     IDS_ERROR, "ERROR: "
     IDS_NOARCHIVE, "Archive not found"
+    IDS_UNSUPPENV, "Lavender cannot run in your environment."
 
     IDS_ENTERDSN, "Enter Disk Serial Number"
     IDS_ENTERDSN_DESC, "Please type the serial number\nattached to Your program diskette."

--- a/src/resource.PLK.rc
+++ b/src/resource.PLK.rc
@@ -5,6 +5,7 @@ LANGUAGE LCID_PLK, 0x1
 {
     IDS_ERROR, "BLAD: "
     IDS_NOARCHIVE, "Nie znaleziono archiwum"
+    IDS_UNSUPPENV, "Lavender nie uruchomi sie w Twoim srodowisku."
 
     IDS_ENTERDSN, "Wprowadź numer seryjny dysku"
     IDS_ENTERDSN_DESC, "Proszę podać numer seryjny dołączony\ndo dyskietki z programem."

--- a/src/resource.h
+++ b/src/resource.h
@@ -2,6 +2,7 @@
 
 #define IDS_ERROR     0x00
 #define IDS_NOARCHIVE 0x01
+#define IDS_UNSUPPENV 0x0F
 
 #define IDS_ENTERDSN       0x10
 #define IDS_ENTERDSN_DESC  0x11


### PR DESCRIPTION
Additionally, translate the error message.

This fixes #88 