### PR TITLE
Add initial Linux target support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ CC      = gcc
 LD      = gcc
 OBJCOPY = objcopy
 
-W32OBJCOPY = x86_64-w64-mingw32-objcopy
-W32WINDRES = x86_64-w64-mingw32-windres
+W32OBJCOPY = i686-w64-mingw32-objcopy
+W32WINDRES = i686-w64-mingw32-windres
+W64WINDRES = x86_64-w64-mingw32-windres
+WINDRES    = $(W64WINDRES)
 
 BIN     = bin
 OBJ     = obj
@@ -25,6 +27,7 @@ ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
 LDFLAGS = -lc -no-pie
 
+RESSUFF = .obj
 OBJFMT  = elf64-x86-64
 
 ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
@@ -52,7 +55,7 @@ include sources.mk
 $(BINPREF)/$(SSHOW): $(BINPREF)/lavender$(EXESUFF) $(OBJ)/data.zip
 	cat $^ > $@
 
-$(BINPREF)/lavender$(EXESUFF): $(OBJ)/version.o $(ASSOURCES:%.S=$(OBJPREF)/%.S.o) $(CCSOURCES:%.c=$(OBJPREF)/%.c.o) $(OBJPREF)/resource.$(LAV_LANG).o
+$(BINPREF)/lavender$(EXESUFF): $(OBJ)/version.o $(ASSOURCES:%.S=$(OBJPREF)/%.S.o) $(CCSOURCES:%.c=$(OBJPREF)/%.c.o) $(OBJPREF)/resource.$(LAV_LANG)$(RESSUFF)
 	@mkdir -p $(BINPREF)
 	$(LD) -o $@ $^ $(LDFLAGS)
 
@@ -72,7 +75,7 @@ $(OBJPREF)/resource.$(LAV_LANG).o: $(OBJPREF)/resource.$(LAV_LANG).obj
 	$(W32OBJCOPY) $< $@ -O $(OBJFMT) --rename-section .rsrc=.rodata.rsrc --add-symbol __w32_rsrc_start=.rodata.rsrc:0
 
 $(OBJPREF)/resource.$(LAV_LANG).obj: $(SRC)/resource.$(LAV_LANG).rc
-	$(W32WINDRES) -c 65001 $< $@ -Iinc/
+	$(WINDRES) -c 65001 $< $@ -Iinc/
 
 GIT_TAG     = $(shell git describe --abbrev=0)
 GIT_COMMITS = $(shell git rev-list $(GIT_TAG)..HEAD --count)

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CC      = gcc
 LD      = ld
 OBJCOPY = objcopy
 
-W32OBJCOPY = i686-w64-mingw32-objcopy
-W32WINDRES = i686-w64-mingw32-windres
+W32OBJCOPY = x86_64-w64-mingw32-objcopy
+W32WINDRES = x86_64-w64-mingw32-windres
 
 BIN     = bin
 OBJ     = obj
@@ -24,6 +24,7 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
 
+OBJFMT  = elf64-x86-64
 
 ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 include Makefile.dospc
@@ -65,7 +66,7 @@ $(OBJPREF)/%.c.o: $(SRC)/%.c
 
 $(OBJPREF)/resource.$(LAV_LANG).o: $(OBJPREF)/resource.$(LAV_LANG).obj
 	@mkdir -p $(@D)
-	$(W32OBJCOPY) $< $@ -O elf32-i386 --rename-section .rsrc=.rodata.rsrc --add-symbol __w32_rsrc_start=.rodata.rsrc:0
+	$(W32OBJCOPY) $< $@ -O $(OBJFMT) --rename-section .rsrc=.rodata.rsrc --add-symbol __w32_rsrc_start=.rodata.rsrc:0
 
 $(OBJPREF)/resource.$(LAV_LANG).obj: $(SRC)/resource.$(LAV_LANG).rc
 	$(W32WINDRES) -c 65001 $< $@ -Iinc/
@@ -80,7 +81,7 @@ VERSION = $(GIT_TAG)-$(GIT_COMMITS)
 endif
 
 $(OBJ)/version.o: $(OBJ)/version.txt .FORCE
-	$(OBJCOPY) -I binary -O elf32-i386 -B i386 --rename-section .data=.rodata $< $@
+	$(OBJCOPY) -I binary -O $(OBJFMT) --rename-section .data=.rodata $< $@
 
 $(OBJ)/version.txt: .FORCE
 	@mkdir -p $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 AS      = gcc
 CC      = gcc
-LD      = ld
+LD      = gcc
 OBJCOPY = objcopy
 
 W32OBJCOPY = x86_64-w64-mingw32-objcopy
@@ -23,11 +23,14 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
+LDFLAGS = -lc -no-pie
 
 OBJFMT  = elf64-x86-64
 
 ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 include Makefile.dospc
+else
+CFLAGS += -g -no-pie
 endif
 
 ifdef LAV_DATA

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-AS      = ia16-elf-gcc
-CC      = ia16-elf-gcc
-LD      = ia16-elf-ld
-OBJCOPY = ia16-elf-objcopy
+AS      = gcc
+CC      = gcc
+LD      = ld
+OBJCOPY = objcopy
 
 W32OBJCOPY = i686-w64-mingw32-objcopy
 W32WINDRES = i686-w64-mingw32-windres
@@ -21,20 +21,12 @@ endif
 BINPREF = $(BIN)/$(LAV_TARGET)/$(LAV_LANG)
 OBJPREF = $(OBJ)/$(LAV_TARGET)
 
-ASFLAGS = -S -march=i8088  -Iinc/
-CFLAGS  = -c -march=i8088 -Os -Wall -Werror -fno-strict-aliasing -Iinc/
+ASFLAGS = -S -Iinc/
+CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
 
-ifeq ($(LAV_TARGET),dospc-exe)
-LD      = ia16-elf-gcc
-CFLAGS += -mcmodel=small
-LDFLAGS = -mcmodel=small -li86 -Wl,--nmagic -Wl,-Map=$(BINPREF)/lavender.map
-EXESUFF = .exe
-endif
 
-ifeq ($(LAV_TARGET),dospc-com)
-CFLAGS += -DZIP_PIGGYBACK
-LDFLAGS = -L/usr/lib/x86_64-linux-gnu/gcc/ia16-elf/6.3.0 -L/usr/ia16-elf/lib -T com.ld -li86 --nmagic -Map=$(BINPREF)/lavender.map
-EXESUFF = .com
+ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
+include Makefile.dospc
 endif
 
 ifdef LAV_DATA
@@ -55,7 +47,6 @@ include sources.mk
 
 $(BINPREF)/$(SSHOW): $(BINPREF)/lavender$(EXESUFF) $(OBJ)/data.zip
 	cat $^ > $@
-	@if [ $$(stat -L -c %s $@) -gt 65280 ]; then echo >&2 "'$@' size exceeds 65,280 bytes"; false; fi
 
 $(BINPREF)/lavender$(EXESUFF): $(OBJ)/version.o $(ASSOURCES:%.S=$(OBJPREF)/%.S.o) $(CCSOURCES:%.c=$(OBJPREF)/%.c.o) $(OBJPREF)/resource.$(LAV_LANG).o
 	@mkdir -p $(BINPREF)

--- a/Makefile.dospc
+++ b/Makefile.dospc
@@ -6,6 +6,8 @@ OBJCOPY = ia16-elf-objcopy
 ASFLAGS+= -march=i8088
 CFLAGS += -march=i8088
 
+OBJFMT  = elf32-i386
+
 ifeq ($(LAV_TARGET),dospc-exe)
 LD      = ia16-elf-gcc
 CFLAGS += -mcmodel=small -Wall -Werror

--- a/Makefile.dospc
+++ b/Makefile.dospc
@@ -1,0 +1,20 @@
+AS      = ia16-elf-gcc
+CC      = ia16-elf-gcc
+LD      = ia16-elf-ld
+OBJCOPY = ia16-elf-objcopy
+
+ASFLAGS+= -march=i8088
+CFLAGS += -march=i8088
+
+ifeq ($(LAV_TARGET),dospc-exe)
+LD      = ia16-elf-gcc
+CFLAGS += -mcmodel=small -Wall -Werror
+LDFLAGS = -mcmodel=small -li86 -Wl,--nmagic -Wl,-Map=$(BINPREF)/lavender.map
+EXESUFF = .exe
+endif
+
+ifeq ($(LAV_TARGET),dospc-com)
+CFLAGS += -DZIP_PIGGYBACK
+LDFLAGS = -L/usr/lib/x86_64-linux-gnu/gcc/ia16-elf/6.3.0 -L/usr/ia16-elf/lib -T com.ld -li86 --nmagic -Map=$(BINPREF)/lavender.map
+EXESUFF = .com
+endif

--- a/Makefile.dospc
+++ b/Makefile.dospc
@@ -2,10 +2,12 @@ AS      = ia16-elf-gcc
 CC      = ia16-elf-gcc
 LD      = ia16-elf-ld
 OBJCOPY = ia16-elf-objcopy
+WINDRES = $(W32WINDRES)
 
 ASFLAGS+= -march=i8088
 CFLAGS += -march=i8088
 
+RESSUFF = .o
 OBJFMT  = elf32-i386
 
 ifeq ($(LAV_TARGET),dospc-exe)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf g++-mingw-w64-i686 libi86-ia16-elf zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-x86-64 libi86-ia16-elf zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ parameters:
   default:
     - dospc-com
     - dospc-exe
+    - test
 
 - name: languages
   type: object
@@ -27,7 +28,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf gcc-mingw-w64-x86-64 libi86-ia16-elf zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/data/slides.txt
+++ b/data/slides.txt
@@ -5,10 +5,10 @@
 500     T   19  ^Version 0.3
 500     T   23  ^Copyright (c) Mateusz Karcz, 2021-2023. Shared under the MIT License.
 0       K
-0       =   3   ExtendedFont
-0       =   4   Rectangles
-0       =   5   Encryption
-0       =   1   End
+0       =   50  ExtendedFont
+0       =   51  Rectangles
+0       =   52  Encryption
+0       =   27  End
 0       J   Start
 :ExtendedFont
 0       r   0   <640 200 B
@@ -20,10 +20,10 @@
 0       T   6   ^•‼←↑→↓↔↕↨∟⌂▬▲►▼◄○◘◙☺☻☼♀♂♠♣♥♦♪♫
 0       K
 0       A   0   0   0   0   0
-0       =   2   Start
-0       =   4   Rectangles
-0       =   5   Encryption
-0       =   1   End
+0       =   49  Start
+0       =   51  Rectangles
+0       =   52  Encryption
+0       =   27  End
 0       J   ExtendedFont
 :Rectangles
 0       r   0   <640 200 B
@@ -34,10 +34,10 @@
 500     R   25  25  50  50  G
 500     r   25  85  50  50  B
 0       K
-0       =   2   Start
-0       =   3   ExtendedFont
-0       =   5   Encryption
-0       =   1   End
+0       =   49  Start
+0       =   50  ExtendedFont
+0       =   52  Encryption
+0       =   27  End
 0       J   Rectangles
 :Encryption
 0       r   0   <640 200 B

--- a/inc/base.h
+++ b/inc/base.h
@@ -31,6 +31,11 @@ typedef union {
 extern uint64_t
 rstrtoull(const char *restrict str, int base);
 
+#if !__MISC_VISIBLE
+extern char *
+itoa(int value, char *str, int base);
+#endif
+
 #ifndef EFTYPE
 #define EFTYPE 0x11e
 #endif

--- a/inc/base.h
+++ b/inc/base.h
@@ -1,6 +1,7 @@
 #ifndef _BASE_H_
 #define _BASE_H_
 
+#include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -29,5 +30,9 @@ typedef union {
 
 extern uint64_t
 rstrtoull(const char *restrict str, int base);
+
+#ifndef EFTYPE
+#define EFTYPE 0x11e
+#endif
 
 #endif // _BASE_H_

--- a/inc/fmt/exe.h
+++ b/inc/fmt/exe.h
@@ -130,4 +130,10 @@ typedef struct
 
 #define EXE_PE_RT_STRING 6
 
+extern const char *
+exe_pe_get_resource(void *rsrc, WORD type, WORD id);
+
+extern int
+exe_pe_load_string(void *rsrc, unsigned id, char *buffer, int max_length);
+
 #endif // _FMT_EXE_H_

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -1,8 +1,9 @@
 #ifndef _FMT_ZIP_H_
 #define _FMT_ZIP_H_
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <assert.h>
+
+#include <base.h>
 
 #define ZIP_PK_SIGN         0x4B50
 #define ZIP_LOCAL_FILE_SIGN 0x0403
@@ -80,6 +81,8 @@
 
 #define ZIP_EXTRA_INFOZIP_UNICODE_PATH 0x7075
 
+#pragma pack(push, 1)
+
 typedef struct
 {
     uint16_t pk_signature;
@@ -93,6 +96,8 @@ typedef struct
     uint16_t comment_length;
     char     comment[];
 } zip_cdir_end_header;
+static_assert(22 == sizeof(zip_cdir_end_header),
+              "Central directory end header size doesn't match specification");
 
 typedef struct
 {
@@ -116,6 +121,8 @@ typedef struct
     uint32_t lfh_offset;
     char     name[];
 } zip_cdir_file_header;
+static_assert(46 == sizeof(zip_cdir_file_header),
+              "Central directory file header size doesn't match specification");
 
 typedef struct
 {
@@ -133,12 +140,16 @@ typedef struct
     uint16_t extra_length;
     char     name[];
 } zip_local_file_header;
+static_assert(30 == sizeof(zip_local_file_header),
+              "Local file header size doesn't match specification");
 
 typedef struct
 {
     uint16_t signature;
     uint16_t total_size;
 } zip_extra_fields_header;
+static_assert(4 == sizeof(zip_extra_fields_header),
+              "Extra fields header size doesn't match specification");
 
 typedef struct
 {
@@ -148,6 +159,10 @@ typedef struct
     uint32_t name_crc32;
     char     unicode_name[];
 } zip_extra_unicode_path_field;
+static_assert(10 == sizeof(zip_extra_unicode_path_field),
+              "Extra Unicode path field size doesn't match specification");
+
+#pragma pack(pop)
 
 #ifdef ZIP_PIGGYBACK
 typedef zip_cdir_end_header *zip_archive;

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -10,6 +10,37 @@ DEFINE_HANDLE(hasset);
 #define PAL_MOUSE_LBUTTON 0x0001
 #define PAL_MOUSE_RBUTTON 0x0002
 
+#ifndef VK_BACK
+// Virtual key code definitions borrowed from Windows API
+// Codes for 0-9 and A-Z are the same as ASCII
+#define VK_BACK       0x08
+#define VK_TAB        0x09
+#define VK_RETURN     0x0D
+#define VK_ESCAPE     0x1B
+#define VK_PRIOR      0x21
+#define VK_NEXT       0x22
+#define VK_END        0x23
+#define VK_HOME       0x24
+#define VK_LEFT       0x25
+#define VK_UP         0x26
+#define VK_RIGHT      0x27
+#define VK_DOWN       0x28
+#define VK_INSERT     0x2D
+#define VK_DELETE     0x2E
+#define VK_F1         0x70
+#define VK_F2         0x71
+#define VK_F3         0x72
+#define VK_F4         0x73
+#define VK_F5         0x74
+#define VK_F6         0x75
+#define VK_F7         0x76
+#define VK_F8         0x77
+#define VK_F9         0x78
+#define VK_F10        0x79
+#define VK_F11        0x7A
+#define VK_F12        0x7B
+#endif
+
 extern void
 pal_initialize(int argc, char *argv[]);
 

--- a/inc/snd.h
+++ b/inc/snd.h
@@ -1,7 +1,6 @@
 #ifndef _SND_H_
 #define _SND_H_
 
-#include <base.h>
 #include <fmt/midi.h>
 
 typedef struct

--- a/src/dlg/fullscrn.c
+++ b/src/dlg/fullscrn.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <api/bios.h>
 #include <dlg.h>
 #include <fmt/utf8.h>
 #include <gfx.h>
@@ -291,21 +290,19 @@ _handle_prompt(void)
         return DLG_INCOMPLETE;
     }
 
-    uint16_t key = bios_check_keystroke();
-    if (0 == key)
+    uint16_t scancode = pal_get_keystroke();
+    if (0 == scancode)
     {
         return DLG_INCOMPLETE;
     }
 
-    bios_get_keystroke();
-    uint8_t scancode = key >> 8, character = key & 0xFF;
-    if (0x01 == scancode)
+    if (VK_ESCAPE == scancode)
     {
         _state = STATE_NONE;
         return 0;
     }
 
-    if (0x1C == scancode)
+    if (VK_RETURN == scancode)
     {
         if (_validator && _validator(_buffer))
         {
@@ -325,16 +322,16 @@ _handle_prompt(void)
         return DLG_INCOMPLETE;
     }
 
-    if ((0x0E == scancode) && (0 < _cursor))
+    if ((VK_BACK == scancode) && (0 < _cursor))
     {
         _cursor--;
         _buffer[_cursor] = 0;
         _draw_text_box();
     }
 
-    if ((0x20 <= character) && (0x80 > character) && (_cursor < _size))
+    if ((0x20 <= scancode) && (0x80 > scancode) && (_cursor < _size))
     {
-        _buffer[_cursor] = key & 0xFF;
+        _buffer[_cursor] = scancode & 0xFF;
         _cursor++;
         _buffer[_cursor] = 0;
         _draw_text_box();

--- a/src/fmt/exe.c
+++ b/src/fmt/exe.c
@@ -1,0 +1,86 @@
+#include <string.h>
+
+#include <fmt/exe.h>
+#include <fmt/utf8.h>
+
+const char *
+exe_pe_get_resource(void *rsrc, WORD type, WORD id)
+{
+    exe_pe_resource_directory       *dir;
+    exe_pe_resource_directory_entry *ent;
+
+    // Type
+    dir = (exe_pe_resource_directory *)rsrc;
+    ent = (exe_pe_resource_directory_entry *)(dir + 1);
+    ent += dir->NumberOfNamedEntries;
+    for (int i = 0; (dir->NumberOfIdEntries > i) && (type != ent->Id);
+         ++i, ++ent)
+        ;
+
+    if (type != ent->Id)
+    {
+        return NULL;
+    }
+
+    // Item
+    dir = (exe_pe_resource_directory *)(rsrc + ent->dir.OffsetToDirectory);
+    ent = (exe_pe_resource_directory_entry *)(dir + 1);
+    ent += dir->NumberOfNamedEntries;
+    for (int i = 0; (dir->NumberOfIdEntries > i) && (id != ent->Id); ++i, ++ent)
+        ;
+
+    if (id != ent->Id)
+    {
+        return NULL;
+    }
+
+    // Language: first available
+    dir = (exe_pe_resource_directory *)(rsrc + ent->dir.OffsetToDirectory);
+    ent = (exe_pe_resource_directory_entry *)(dir + 1);
+
+    exe_pe_resource_data_entry *data =
+        (exe_pe_resource_data_entry *)(rsrc + ent->OffsetToData);
+    return (char *)(intptr_t)data->OffsetToData;
+}
+
+int
+exe_pe_load_string(void *rsrc, unsigned id, char *buffer, int max_length)
+{
+    const char *resource =
+        exe_pe_get_resource(rsrc, EXE_PE_RT_STRING, (id >> 4) + 1);
+    if (NULL == resource)
+    {
+        return -1;
+    }
+
+    // One table = 16 strings
+    const uint16_t *wstr = (const uint16_t *)resource;
+    for (int i = 0; (id & 0xF) > i; ++i)
+    {
+        wstr += *wstr + 1;
+    }
+
+    // First WORD is string length
+    const uint16_t *end = wstr + *wstr + 1;
+    wstr++;
+
+    // Convert WSTR to UTF-8
+    char *buffptr = buffer;
+    while ((wstr < end) && (buffer + max_length > buffptr))
+    {
+        char mb[3];
+
+        int seqlen = utf8_get_sequence(*wstr, mb);
+        if (buffer + max_length < buffptr + seqlen)
+        {
+            break;
+        }
+
+        memcpy(buffptr, mb, seqlen);
+        wstr++;
+        buffptr += seqlen;
+    }
+
+    *buffptr = 0;
+    return buffptr - buffer;
+}

--- a/src/fmt/iff.c
+++ b/src/fmt/iff.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <stdlib.h>
 
 #include <fmt/iff.h>

--- a/src/fmt/module.mk
+++ b/src/fmt/module.mk
@@ -1,5 +1,6 @@
 CCSOURCES := $(CCSOURCES) \
 	$(DIR)/utf8.c \
+	$(DIR)/exe.c \
 	$(DIR)/zip.c \
 	$(DIR)/pbm.c \
 	$(DIR)/iff.c \

--- a/src/fmt/pbm.c
+++ b/src/fmt/pbm.c
@@ -1,8 +1,6 @@
 #include <ctype.h>
-#include <errno.h>
 #include <stdlib.h>
 
-#include <api/dos.h>
 #include <fmt/pbm.h>
 
 static int

--- a/src/fmt/utf8.c
+++ b/src/fmt/utf8.c
@@ -1,6 +1,3 @@
-#include <errno.h>
-#include <stdint.h>
-
 #include <fmt/utf8.h>
 
 uint16_t

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -1,6 +1,5 @@
 
 #include <alloca.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/gfx/cga.c
+++ b/src/gfx/cga.c
@@ -1,5 +1,4 @@
 #include <dos.h>
-#include <errno.h>
 #include <graph.h>
 #include <libi86/string.h>
 

--- a/src/gfx/module.mk
+++ b/src/gfx/module.mk
@@ -1,1 +1,3 @@
+ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 CCSOURCES := $(CCSOURCES) $(DIR)/cga.c $(DIR)/vbe.c $(DIR)/font-8x8.c
+endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -1,5 +1,4 @@
 #include <conio.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <libi86/string.h>
 #include <stdio.h>

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -1,4 +1,5 @@
 #include <conio.h>
+#include <ctype.h>
 #include <fcntl.h>
 #include <libi86/string.h>
 #include <stdio.h>
@@ -603,7 +604,61 @@ pal_get_keystroke(void)
         return 0;
     }
 
-    return bios_get_keystroke() >> 8;
+    uint16_t keystroke = bios_get_keystroke();
+    if (keystroke & 0xFF)
+    {
+        return toupper(keystroke & 0xFF);
+    }
+
+    switch (keystroke >> 8)
+    {
+    case 0x3B:
+        return VK_F1;
+    case 0x3C:
+        return VK_F2;
+    case 0x3D:
+        return VK_F3;
+    case 0x3E:
+        return VK_F4;
+    case 0x3F:
+        return VK_F5;
+    case 0x40:
+        return VK_F6;
+    case 0x41:
+        return VK_F7;
+    case 0x42:
+        return VK_F8;
+    case 0x43:
+        return VK_F9;
+    case 0x44:
+        return VK_F10;
+    case 0x47:
+        return VK_HOME;
+    case 0x48:
+        return VK_UP;
+    case 0x49:
+        return VK_PRIOR;
+    case 0x4B:
+        return VK_LEFT;
+    case 0x4D:
+        return VK_RIGHT;
+    case 0x4F:
+        return VK_END;
+    case 0x50:
+        return VK_DOWN;
+    case 0x51:
+        return VK_NEXT;
+    case 0x52:
+        return VK_INSERT;
+    case 0x53:
+        return VK_DELETE;
+    case 0x85:
+        return VK_F11;
+    case 0x86:
+        return VK_F12;
+    default:
+        return 0;
+    }
 }
 
 void

--- a/src/pal/log.c
+++ b/src/pal/log.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+#include "pal_impl.h"
+
+void
+__pal_log_time(void)
+{
+    uint32_t counter = pal_get_counter();
+    fprintf(stderr, "[%4u.%03u] ", counter / 1000, counter % 1000);
+}

--- a/src/pal/module.mk
+++ b/src/pal/module.mk
@@ -4,3 +4,7 @@ ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 ASSOURCES := $(ASSOURCES) $(DIR)/dospc.S
 CCSOURCES := $(CCSOURCES) $(DIR)/dospc.c
 endif
+
+ifeq ($(LAV_TARGET),test)
+CCSOURCES := $(CCSOURCES) $(DIR)/log.c $(DIR)/test.c
+endif

--- a/src/pal/module.mk
+++ b/src/pal/module.mk
@@ -1,2 +1,4 @@
+ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 ASSOURCES := $(ASSOURCES) $(DIR)/dospc.S
 CCSOURCES := $(CCSOURCES) $(DIR)/dospc.c
+endif

--- a/src/pal/module.mk
+++ b/src/pal/module.mk
@@ -1,3 +1,5 @@
+CCSOURCES := $(CCSOURCES) $(DIR)/ziparch.c
+
 ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
 ASSOURCES := $(ASSOURCES) $(DIR)/dospc.S
 CCSOURCES := $(CCSOURCES) $(DIR)/dospc.c

--- a/src/pal/pal_impl.h
+++ b/src/pal/pal_impl.h
@@ -1,0 +1,12 @@
+#include <pal.h>
+
+typedef struct
+{
+    off_t inzip;
+    int   flags;
+    char *data;
+} pal_asset;
+
+#define MAX_OPEN_ASSETS 8
+
+extern pal_asset __pal_assets[MAX_OPEN_ASSETS];

--- a/src/pal/pal_impl.h
+++ b/src/pal/pal_impl.h
@@ -10,3 +10,23 @@ typedef struct
 #define MAX_OPEN_ASSETS 8
 
 extern pal_asset __pal_assets[MAX_OPEN_ASSETS];
+
+#ifdef __linux__
+
+#include <stdio.h>
+
+extern void
+__pal_log_time(void);
+
+#define LOG(fmt, ...)                                                          \
+    {                                                                          \
+        __pal_log_time();                                                      \
+        fprintf(stderr, "%s: ", __FUNCTION__);                                 \
+        fprintf(stderr, fmt "\n", ##__VA_ARGS__);                              \
+    }
+
+#else
+
+#define LOG(fmt, ...)
+
+#endif

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -1,0 +1,277 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <fmt/exe.h>
+#include <fmt/zip.h>
+#include <gfx.h>
+#include <pal.h>
+#include <snd.h>
+
+#include "pal_impl.h"
+
+typedef struct
+{
+    long size;
+} fdata;
+
+extern char _binary_obj_version_txt_start[];
+extern char __w32_rsrc_start[];
+
+long           _start_msec;
+struct termios _old_termios;
+
+void
+pal_initialize(int argc, char *argv[])
+{
+    struct timespec time;
+    clock_gettime(CLOCK_BOOTTIME, &time);
+    _start_msec = time.tv_sec * 1000 + time.tv_nsec / 1000000;
+
+    LOG("entry");
+
+    if (!zip_open(argv[0]))
+    {
+        LOG("cannot open the archive '%s'. %s", argv[0], strerror(errno));
+        abort();
+    }
+
+    for (int i = 0; i < MAX_OPEN_ASSETS; ++i)
+    {
+        __pal_assets[i].inzip = -1;
+        __pal_assets[i].flags = 0;
+        __pal_assets[i].data = NULL;
+    }
+
+    struct termios new_termios;
+
+    tcgetattr(STDIN_FILENO, &_old_termios);
+    memcpy(&new_termios, &_old_termios, sizeof(new_termios));
+
+    cfmakeraw(&new_termios);
+    new_termios.c_oflag |= ONLCR | OPOST;
+    tcsetattr(STDIN_FILENO, TCSANOW, &new_termios);
+}
+
+void
+pal_cleanup(void)
+{
+    LOG("entry");
+
+    for (int i = 0; i < MAX_OPEN_ASSETS; ++i)
+    {
+        if (NULL != __pal_assets[i].data)
+        {
+            zip_free_data(__pal_assets[i].data);
+        }
+    }
+
+    tcsetattr(0, TCSANOW, &_old_termios);
+}
+
+uint32_t
+pal_get_counter(void)
+{
+    struct timespec time;
+    clock_gettime(CLOCK_BOOTTIME, &time);
+
+    long time_msec = time.tv_sec * 1000 + time.tv_nsec / 1000000;
+    return time_msec - _start_msec;
+}
+
+uint32_t
+pal_get_ticks(unsigned ms)
+{
+    return ms;
+}
+
+void
+pal_sleep(unsigned ms)
+{
+    LOG("entry, ms: %u", ms);
+
+    usleep(ms);
+}
+
+const char *
+pal_get_version_string(void)
+{
+    return _binary_obj_version_txt_start;
+}
+
+uint32_t
+pal_get_medium_id(const char *tag)
+{
+    LOG("entry");
+    return 0;
+}
+
+uint16_t
+pal_get_keystroke(void)
+{
+    struct timeval tv = {0L, 0L};
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(STDIN_FILENO, &fds);
+    if (0 == select(1, &fds, NULL, NULL, &tv))
+    {
+        return 0;
+    }
+
+    char c;
+    if (0 > read(STDIN_FILENO, &c, sizeof(c)))
+    {
+        return 0;
+    }
+
+    if (0x7F == c)
+    {
+        c = VK_BACK;
+    }
+
+    LOG("keystroke: %#.2x", c);
+    return c;
+}
+
+void
+pal_enable_mouse(void)
+{
+    LOG("entry");
+    return;
+}
+
+void
+pal_disable_mouse(void)
+{
+    LOG("entry");
+    return;
+}
+
+uint16_t
+pal_get_mouse(uint16_t *x, uint16_t *y)
+{
+    return 0;
+}
+
+int
+pal_load_string(unsigned id, char *buffer, int max_length)
+{
+    LOG("entry, id: %u, buffer: %p, max_length: %d", id, buffer, max_length);
+
+    int length = exe_pe_load_string(__w32_rsrc_start, id, buffer, max_length);
+    if (0 > length)
+    {
+        const char msg[] = "!!! string missing !!!";
+        strncpy(buffer, msg, max_length);
+
+        LOG("exit, string missing");
+        return sizeof(msg) - 1;
+    }
+
+    LOG("exit, '%s'", buffer);
+    return length;
+}
+
+bool
+gfx_initialize(void)
+{
+    LOG("entry");
+    return true;
+}
+
+void
+gfx_cleanup(void)
+{
+    LOG("entry");
+}
+
+void
+gfx_get_screen_dimensions(gfx_dimensions *dim)
+{
+    LOG("entry");
+
+    dim->width = 640;
+    dim->height = 200;
+
+    LOG("exit, %dx%d", dim->width, dim->height);
+}
+
+uint16_t
+gfx_get_pixel_aspect(void)
+{
+    LOG("entry");
+
+    uint16_t ratio = 64 * (1);
+
+    LOG("exit, ratio: 1:%.2f", (float)ratio / 64.0f);
+    return ratio;
+}
+
+bool
+gfx_draw_bitmap(gfx_bitmap *bm, uint16_t x, uint16_t y)
+{
+    LOG("entry, bm: %ux%u %ubpp (%u planes, %u octets per scanline), x: %u,"
+        " y: %u",
+        bm->width, bm->height, bm->bpp, bm->planes, bm->opl, x, y);
+
+    return true;
+}
+
+bool
+gfx_draw_line(gfx_dimensions *dim, uint16_t x, uint16_t y, gfx_color color)
+{
+    LOG("entry, dim: %dx%d, x: %u, y: %u, color: %d", dim->width, dim->height,
+        x, y, color);
+
+    return true;
+}
+
+bool
+gfx_draw_rectangle(gfx_dimensions *rect,
+                   uint16_t        x,
+                   uint16_t        y,
+                   gfx_color       color)
+{
+    LOG("entry, dim: %dx%d, x: %u, y: %u, color: %d", rect->width, rect->height,
+        x, y, color);
+
+    return true;
+}
+
+bool
+gfx_fill_rectangle(gfx_dimensions *rect,
+                   uint16_t        x,
+                   uint16_t        y,
+                   gfx_color       color)
+{
+    LOG("entry, dim: %dx%d, x: %u, y: %u, color: %d", rect->width, rect->height,
+        x, y, color);
+
+    return true;
+}
+
+bool
+gfx_draw_text(const char *str, uint16_t x, uint16_t y)
+{
+    LOG("entry, str: '%s', x: %u, y: %u", str, x, y);
+
+    return true;
+}
+
+char
+gfx_wctob(uint16_t wc)
+{
+    return (0x80 > wc) ? wc : '?';
+}
+
+void
+snd_send(const char *msg, size_t length)
+{
+    LOG("entry, length: %zd", length);
+}

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -21,7 +21,16 @@ typedef struct
 } fdata;
 
 extern char _binary_obj_version_txt_start[];
-extern char __w32_rsrc_start[];
+
+// FIXME: W/A for https://sourceware.org/bugzilla/show_bug.cgi?id=30719
+#ifndef __x86_64__
+extern
+#endif
+    char __w32_rsrc_start[]
+#ifdef __x86_64__
+    __attribute__((section(".rsrc"))) = {}
+#endif
+;
 
 long           _start_msec;
 struct termios _old_termios;

--- a/src/pal/ziparch.c
+++ b/src/pal/ziparch.c
@@ -1,0 +1,99 @@
+#include <string.h>
+
+#include <fmt/zip.h>
+
+#include "pal_impl.h"
+
+pal_asset __pal_assets[MAX_OPEN_ASSETS];
+
+hasset
+pal_open_asset(const char *name, int flags)
+{
+    off_t lfh = zip_search(name, strlen(name));
+    if (-1 == lfh)
+    {
+        return NULL;
+    }
+
+    int slot = 0;
+    while (-1 != __pal_assets[slot].inzip)
+    {
+        if (lfh == __pal_assets[slot].inzip)
+        {
+            if (O_RDWR == (flags & O_ACCMODE))
+            {
+                __pal_assets[slot].flags = (flags & ~O_ACCMODE) | O_RDWR;
+            }
+
+            return (hasset)(__pal_assets + slot);
+        }
+
+        slot++;
+        if (MAX_OPEN_ASSETS == slot)
+        {
+            errno = ENOMEM;
+            return NULL;
+        }
+    }
+
+    __pal_assets[slot].inzip = lfh;
+    __pal_assets[slot].flags = flags;
+    return (hasset)(__pal_assets + slot);
+}
+
+bool
+pal_close_asset(hasset asset)
+{
+    pal_asset *ptr = (pal_asset *)asset;
+    if (-1 == ptr->inzip)
+    {
+        errno = EBADF;
+        return false;
+    }
+
+    if (O_RDWR == (ptr->flags & O_ACCMODE))
+    {
+        // Do not release modified assets
+        return true;
+    }
+
+    ptr->inzip = -1;
+
+    if (NULL != ptr->data)
+    {
+        zip_free_data(ptr->data);
+        ptr->data = NULL;
+    }
+    return true;
+}
+
+char *
+pal_get_asset_data(hasset asset)
+{
+    pal_asset *ptr = (pal_asset *)asset;
+    if (-1 == ptr->inzip)
+    {
+        errno = EBADF;
+        return NULL;
+    }
+
+    if (NULL == ptr->data)
+    {
+        ptr->data = zip_get_data(ptr->inzip);
+    }
+
+    return ptr->data;
+}
+
+int
+pal_get_asset_size(hasset asset)
+{
+    pal_asset *ptr = (pal_asset *)asset;
+    if (-1 == ptr->inzip)
+    {
+        errno = EBADF;
+        return -1;
+    }
+
+    return zip_get_size(ptr->inzip);
+}

--- a/src/rstd.c
+++ b/src/rstd.c
@@ -1,5 +1,7 @@
 #include <ctype.h>
-#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <base.h>
 
@@ -54,3 +56,24 @@ rstrtoull(const char *restrict str, int base)
         return ULLONG_MAX;
     }
 }
+
+#if !__MISC_VISIBLE
+char *
+itoa(int value, char *str, int base)
+{
+    if (10 == base)
+    {
+        sprintf(str, "%d", value);
+    }
+    else if (16 == base)
+    {
+        sprintf(str, "%x", value);
+    }
+    else
+    {
+        strcpy(str, "?base?");
+    }
+
+    return str;
+}
+#endif

--- a/src/sld/bitmap.c
+++ b/src/sld/bitmap.c
@@ -1,6 +1,3 @@
-#include <errno.h>
-#include <string.h>
-
 #include <fmt/pbm.h>
 #include <pal.h>
 #include <sld.h>

--- a/src/sld/call.c
+++ b/src/sld/call.c
@@ -1,7 +1,6 @@
 #include <assert.h>
 #include <ctype.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <crg.h>
 #include <dlg.h>

--- a/src/sld/call.c
+++ b/src/sld/call.c
@@ -18,14 +18,14 @@
 typedef struct
 {
     // External data
-    char     file_name[64];
+    char     file_name[40];
     uint16_t method;
     uint32_t crc32;
     uint16_t parameter;
     char     data[96];
 
     // Execution state
-    int          state;
+    int16_t      state;
     sld_context *context;
     crg_stream   crs;
     uquad        key;

--- a/src/sld/context.c
+++ b/src/sld/context.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <stdlib.h>
 
 #include "sld_impl.h"

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -1,5 +1,3 @@
-#include <string.h>
-
 #include <pal.h>
 #include <snd.h>
 

--- a/src/snd/fmidi.c
+++ b/src/snd/fmidi.c
@@ -1,5 +1,3 @@
-#include <errno.h>
-
 #include <pal.h>
 #include <snd.h>
 

--- a/src/snd/fspk.c
+++ b/src/snd/fspk.c
@@ -1,5 +1,3 @@
-#include <errno.h>
-
 #include <fmt/spk.h>
 #include <pal.h>
 #include <snd.h>

--- a/src/snd/module.mk
+++ b/src/snd/module.mk
@@ -1,5 +1,9 @@
 CCSOURCES := $(CCSOURCES) \
 	$(DIR)/snd.c \
-	$(DIR)/dpcspk.c \
 	$(DIR)/fmidi.c \
 	$(DIR)/fspk.c
+
+ifeq ($(findstring dospc,$(LAV_TARGET)),dospc)
+CCSOURCES := $(CCSOURCES) \
+	$(DIR)/dpcspk.c
+endif


### PR DESCRIPTION
- extract Win32 resource related code
- fix structures in the 64-bit environment
- include `errno.h` in `base.h`
- utilize virtual key codes instead of raw scan codes
- extract dospc specific Makefile parts
- add diagnostic Linux x86_64 target
- implement W/A for https://sourceware.org/bugzilla/show_bug.cgi?id=30719