### PR TITLE
Fix handling of the passcode prompt

### DIFF
--- a/src/dlg/fullscrn.c
+++ b/src/dlg/fullscrn.c
@@ -204,13 +204,13 @@ _handle_alert(void)
         return DLG_INCOMPLETE;
     }
 
-    if (0x01 == scancode)
+    if (VK_ESCAPE == scancode)
     {
         _state = STATE_NONE;
         return DLG_CANCEL;
     }
 
-    if (0x1C == scancode)
+    if (VK_RETURN == scancode)
     {
         _state = STATE_NONE;
         return DLG_OK;
@@ -329,7 +329,8 @@ _handle_prompt(void)
         _draw_text_box();
     }
 
-    if ((0x20 <= scancode) && (0x80 > scancode) && (_cursor < _size))
+    if (((' ' == scancode) || ((VK_DELETE < scancode) && (VK_F1 > scancode))) &&
+        (_cursor < _size))
     {
         _buffer[_cursor] = scancode & 0xFF;
         _cursor++;

--- a/src/sld/call.c
+++ b/src/sld/call.c
@@ -291,10 +291,33 @@ _handle_passcode_type(sld_entry *sld)
     return CONTINUE;
 }
 
+static uint8_t
+_axtob(const char *str)
+{
+    if (!isxdigit(str[0]) || !isxdigit(str[1]))
+    {
+        return 0;
+    }
+
+    uint8_t ret =
+        isdigit(str[0]) ? (str[1] - '0') : (toupper(str[1]) - 'A' + 10);
+    ret |= (isdigit(str[0]) ? (str[0] - '0') : (toupper(str[0]) - 'A' + 10))
+           << 4;
+
+    return ret;
+}
+
 static int
 _handle_passcode_validate(sld_entry *sld)
 {
-    if (SLD_PARAMETER_XOR48_PROMPT != CONTENT(sld)->parameter)
+    if (SLD_PARAMETER_XOR48_PROMPT == CONTENT(sld)->parameter)
+    {
+        for (int i = 0; i < 6; i++)
+        {
+            CONTENT(sld)->key.b[i] = _axtob(CONTENT(sld)->buffer + i * 2);
+        }
+    }
+    else
     {
         // 48-bit split key
         CONTENT(sld)->key.qw =


### PR DESCRIPTION
- utilize virtual keys in the alert handle routine (fixes #102)
- restore conversion of manually typed XOR48 passcodes (fixes #104)