### PR TITLE
Add support for graphics, sound, and input in the Linux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
-LDFLAGS = -lc -lSDL2 -lSDL2_ttf -lfontconfig -no-pie
+LDFLAGS = -lc -lSDL2 -lSDL2_ttf -lfontconfig -lfluidsynth -no-pie
 
 RESSUFF = .obj
 OBJFMT  = elf64-x86-64

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
-LDFLAGS = -lc -lSDL2 -lSDL2_ttf -no-pie
+LDFLAGS = -lc -lSDL2 -lSDL2_ttf -lfontconfig -no-pie
 
 RESSUFF = .obj
 OBJFMT  = elf64-x86-64

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
-LDFLAGS = -lc -no-pie
+LDFLAGS = -lc -lSDL2 -no-pie
 
 RESSUFF = .obj
 OBJFMT  = elf64-x86-64

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJPREF = $(OBJ)/$(LAV_TARGET)
 
 ASFLAGS = -S -Iinc/
 CFLAGS  = -c -Os -fno-strict-aliasing -Iinc/
-LDFLAGS = -lc -lSDL2 -no-pie
+LDFLAGS = -lc -lSDL2 -lSDL2_ttf -no-pie
 
 RESSUFF = .obj
 OBJFMT  = elf64-x86-64

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is still work in progress, but I'm doing my best to separate working versio
 * diagnostic Linux target
 
 ## Building
-Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64 with SDL2 and SDL2_ttf, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
+Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64 with SDL2, SDL2_ttf, and FluidSynth, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
 ```sh
 make
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is still work in progress, but I'm doing my best to separate working versio
 * diagnostic Linux target
 
 ## Building
-Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
+Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64 with SDL2, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
 ```sh
 make
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is still work in progress, but I'm doing my best to separate working versio
 * diagnostic Linux target
 
 ## Building
-Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64 with SDL2, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
+Building requires x86_64 Linux with *GNU Make*, *GNU Binutils*, *MinGW-w64* for i686 and x86_64 with SDL2 and SDL2_ttf, [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/), and `zip`. If you have it, just run:
 ```sh
 make
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev libsdl2-ttf-dev libfontconfig-dev zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libfluidsynth-dev zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev libsdl2-ttf-dev zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev libsdl2-ttf-dev libfontconfig-dev zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
 - script: |
     sudo add-apt-repository ppa:tkchia/build-ia16
     sudo apt update
-    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev zip -y
+    sudo apt install gcc-ia16-elf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 libi86-ia16-elf libsdl2-dev libsdl2-ttf-dev zip -y
   displayName: 'Install additional tools'
 
 - ${{ each target in parameters.targets }}:

--- a/inc/fmt/utf8.h
+++ b/inc/fmt/utf8.h
@@ -1,6 +1,10 @@
 #ifndef _FMT_UTF8_H_
 #define _FMT_UTF8_H_
 
+#ifdef __linux__
+#define UTF8_NATIVE
+#endif
+
 #include <base.h>
 
 // Get code point from UTF-8 sequence

--- a/inc/fmt/utf8.h
+++ b/inc/fmt/utf8.h
@@ -19,10 +19,14 @@ utf8_get_sequence(uint16_t wc, char *buff);
 extern int
 utf8_encode(const char *src, char *dst, char (*encoder)(uint16_t));
 
+// Get character count of UTF-8 string
+// Returns the length of the string, negative on error
+extern int
+utf8_strlen(const char *str);
+
 // Conduct a case-insensitive comparison of two UTF-8 strings
 // Returns 0 when equal, non-zero on difference
 // Clears errno on success
 extern int
 utf8_strncasecmp(const char *str1, const char *str2, unsigned length);
-
 #endif // _FMT_UTF8_H_

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -36,6 +36,10 @@ gfx_cleanup(void);
 extern void
 gfx_get_screen_dimensions(gfx_dimensions *dim);
 
+// Get width and height of a glyph in pixels
+extern void
+gfx_get_glyph_dimensions(gfx_dimensions *dim);
+
 // Get pixel aspect ratio
 // Returns pixel aspect ratio (PAR = 64 / value), default value on error
 extern uint16_t

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -67,6 +67,9 @@ pal_initialize(int argc, char *argv[]);
 extern void
 pal_cleanup(void);
 
+extern void
+pal_handle(void);
+
 extern uint32_t
 pal_get_counter(void);
 

--- a/src/fmt/utf8.c
+++ b/src/fmt/utf8.c
@@ -257,6 +257,25 @@ _fold_case(uint16_t cp, uint16_t *buff)
 }
 
 int
+utf8_strlen(const char *str)
+{
+    int i;
+    for (i = 0; *str; i++)
+    {
+        int length;
+        utf8_get_codepoint(str, &length);
+        if (0 == length)
+        {
+            return -1;
+        }
+
+        str += length;
+    }
+
+    return i;
+}
+
+int
 utf8_strncasecmp(const char *str1, const char *str2, unsigned length)
 {
     errno = 0;

--- a/src/gfx/cga.c
+++ b/src/gfx/cga.c
@@ -161,6 +161,13 @@ gfx_get_screen_dimensions(gfx_dimensions *dim)
     dim->height = CGA_HIMONO_HEIGHT;
 }
 
+void
+gfx_get_glyph_dimensions(gfx_dimensions *dim)
+{
+    dim->width = CGA_CHARACTER_HEIGHT;
+    dim->height = CGA_CHARACTER_HEIGHT;
+}
+
 bool
 gfx_draw_bitmap(gfx_bitmap *bm, uint16_t x, uint16_t y)
 {

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -314,6 +314,11 @@ pal_cleanup(void)
 #endif // STACK_PROFILING
 }
 
+void
+pal_handle(void)
+{
+}
+
 uint32_t
 pal_get_counter(void)
 {

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -192,6 +192,11 @@ pal_cleanup(void)
     }
 }
 
+void
+pal_handle(void)
+{
+}
+
 uint32_t
 pal_get_counter(void)
 {

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -112,7 +112,7 @@ pal_initialize(int argc, char *argv[])
     {
         LOG("cannot match font");
         TTF_Quit();
-        SDL_Quit();
+        pal_cleanup();
         abort();
     }
 
@@ -120,8 +120,7 @@ pal_initialize(int argc, char *argv[])
     if (NULL == _font)
     {
         LOG("cannot open font '%s'. %s", fc_font, SDL_GetError());
-        TTF_Quit();
-        SDL_Quit();
+        pal_cleanup();
         abort();
     }
 
@@ -135,9 +134,7 @@ pal_initialize(int argc, char *argv[])
     if (NULL == _window)
     {
         LOG("cannot create window. %s", SDL_GetError());
-        TTF_CloseFont(_font);
-        TTF_Quit();
-        SDL_Quit();
+        pal_cleanup();
         abort();
     }
 
@@ -145,10 +142,7 @@ pal_initialize(int argc, char *argv[])
     if (NULL == _renderer)
     {
         LOG("cannot create renderer. %s", SDL_GetError());
-        SDL_DestroyWindow(_window);
-        TTF_CloseFont(_font);
-        TTF_Quit();
-        SDL_Quit();
+        pal_cleanup();
         abort();
     }
 
@@ -169,8 +163,22 @@ pal_cleanup(void)
         }
     }
 
-    TTF_CloseFont(_font);
-    TTF_Quit();
+    if (_renderer)
+    {
+        SDL_DestroyRenderer(_renderer);
+    }
+
+    if (_window)
+    {
+        SDL_DestroyWindow(_window);
+    }
+
+    if (_font)
+    {
+        TTF_CloseFont(_font);
+        TTF_Quit();
+    }
+
     SDL_Quit();
 
     if (_wav)

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -310,6 +310,13 @@ gfx_get_screen_dimensions(gfx_dimensions *dim)
     LOG("exit, %dx%d", dim->width, dim->height);
 }
 
+void
+gfx_get_glyph_dimensions(gfx_dimensions *dim)
+{
+    dim->width = _font_w;
+    dim->height = 8;
+}
+
 uint16_t
 gfx_get_pixel_aspect(void)
 {

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -232,6 +232,11 @@ pal_get_keystroke(void)
         c = VK_BACK;
     }
 
+    if (islower(c))
+    {
+        c = toupper(c);
+    }
+
     LOG("keystroke: %#.2x", c);
     return c;
 }

--- a/src/pal/test.c
+++ b/src/pal/test.c
@@ -426,7 +426,7 @@ gfx_draw_text(const char *str, uint16_t x, uint16_t y)
     }
 
     SDL_Surface *surface =
-        TTF_RenderText_Blended(_font, str, COLORS[GFX_COLOR_WHITE]);
+        TTF_RenderUTF8_Blended(_font, str, COLORS[GFX_COLOR_WHITE]);
     SDL_Rect rect = {x * _font_w, y * 16, surface->w, surface->h};
 
     _blend_subtractive(surface, &rect);

--- a/src/sld/bitmap.c
+++ b/src/sld/bitmap.c
@@ -56,14 +56,17 @@ __sld_execute_bitmap(sld_entry *sld)
         return SLD_SYSERR;
     }
 
+    gfx_dimensions screen;
+    gfx_get_screen_dimensions(&screen);
+
     uint16_t x, y = sld->posy;
     switch (sld->posx)
     {
     case SLD_ALIGN_CENTER:
-        x = (LINE_WIDTH - bm.opl) / 2;
+        x = (screen.width / 8 - bm.opl) / 2;
         break;
     case SLD_ALIGN_RIGHT:
-        x = LINE_WIDTH - bm.opl;
+        x = screen.width / 8 - bm.opl;
         break;
     default:
         x = sld->posx;

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -88,6 +88,7 @@ _goto_label(sld_context *ctx, const char *label)
 void
 sld_handle(void)
 {
+    pal_handle();
     snd_handle();
 
     sld_context *ctx = __sld_ctx;

--- a/src/sld/text.c
+++ b/src/sld/text.c
@@ -2,7 +2,8 @@
 
 #include "sld_impl.h"
 
-int
+#ifndef UTF8_NATIVE
+static int
 _convert_text(const char *str, sld_entry *inout)
 {
     inout->length = utf8_encode(inout->content, inout->content, gfx_wctob);
@@ -14,6 +15,7 @@ _convert_text(const char *str, sld_entry *inout)
 
     return 0;
 }
+#endif
 
 int
 __sld_execute_text(sld_entry *sld)
@@ -48,7 +50,11 @@ __sld_load_text(const char *str, sld_entry *out)
 
     __sld_try_load(__sld_load_position, cur, out);
     __sld_try_load(__sld_load_content, cur, out);
+#ifdef UTF8_NATIVE
+    out->length = utf8_strlen(out->content);
+#else
     __sld_try_load(_convert_text, cur, out);
+#endif
 
     return cur - str;
 }


### PR DESCRIPTION
Closes #110 
- utilize SDL2 for graphics rendering and keyboard/mouse input
- utilize SDL2_ttf for text rendering
- utilize fontconfig for font retrieval
- utilize FluidSynth for music playback
- issue program change and note off MIDI events in SPK playback