### PR TITLE
Fix Windows bundle signing and window closing

### DIFF
--- a/inc/fmt/exe.h
+++ b/inc/fmt/exe.h
@@ -91,6 +91,12 @@ typedef struct
 
 typedef struct
 {
+    DWORD VirtualAddress;
+    DWORD Size;
+} exe_pe_data_directory;
+
+typedef struct
+{
     DWORD Characteristics;
     DWORD TimeDateStamp;
     WORD  MajorVersion;
@@ -129,6 +135,8 @@ typedef struct
     DWORD Reserved;
 } exe_pe_resource_data_entry;
 #pragma pack(pop)
+
+#define EXE_PE_DIRECTORY_ENTRY_SECURITY 4
 
 #define EXE_PE_RT_STRING 6
 

--- a/inc/sld.h
+++ b/inc/sld.h
@@ -99,7 +99,7 @@ typedef struct _sld_context
 } sld_context;
 
 extern sld_context *
-sld_create_context(const char *name, sld_context *parent);
+sld_create_context(const char *name, int flags);
 
 extern bool
 sld_close_context(sld_context *ctx);

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ main(int argc, char *argv[])
 
     pal_initialize(argc, argv);
 
-    sld_context *script = sld_create_context("slides.txt", NULL);
+    sld_context *script = sld_create_context("slides.txt", O_RDONLY);
     if (NULL == script)
     {
         char msg[80];

--- a/src/sld/call.c
+++ b/src/sld/call.c
@@ -164,7 +164,9 @@ _validate_dsn(const char *dsn)
 static int
 _handle_prepare(sld_entry *sld)
 {
-    sld_context *script = sld_create_context(CONTENT(sld)->file_name, NULL);
+    sld_context *script = sld_create_context(
+        CONTENT(sld)->file_name,
+        (SLD_METHOD_STORE == CONTENT(sld)->method) ? O_RDONLY : O_RDWR);
     if (NULL == script)
     {
         __sld_errmsgcpy(sld, IDS_NOEXECCTX);

--- a/src/sld/context.c
+++ b/src/sld/context.c
@@ -5,7 +5,7 @@
 sld_context *__sld_ctx = NULL;
 
 sld_context *
-sld_create_context(const char *name, sld_context *parent)
+sld_create_context(const char *name, int flags)
 {
     sld_context *ctx = (sld_context *)malloc(sizeof(sld_context));
     if (NULL == ctx)
@@ -14,7 +14,7 @@ sld_create_context(const char *name, sld_context *parent)
         return NULL;
     }
 
-    ctx->script = pal_open_asset(name, O_RDWR);
+    ctx->script = pal_open_asset(name, flags);
     if (NULL == ctx->script)
     {
         free(ctx);
@@ -33,7 +33,6 @@ sld_create_context(const char *name, sld_context *parent)
     ctx->offset = 0;
     ctx->state = SLD_STATE_STOP;
     memset(ctx->message, 0, sizeof(ctx->message));
-    ctx->parent = parent;
     return ctx;
 }
 

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -104,10 +104,14 @@ sld_handle(void)
         return;
     }
 
-    // SLD_STATE_STOP
-    if (SLD_STATE_STOP == ctx->state)
+    // SLD_STATE_STOP, SLD_QUIT
+    if ((SLD_STATE_STOP == ctx->state) || (SLD_QUIT == ctx->state))
     {
         sld_context *old_ctx = sld_exit_context();
+        if (0 > old_ctx->state)
+        {
+            __sld_ctx->state = old_ctx->state;
+        }
         sld_close_context(old_ctx);
         return;
     }


### PR DESCRIPTION
- allow signed bundles under Windows - fixes #143 
- propagate error status to parent context - fixes #144 
- set access mode at sld context creation to preserve memory