### PR TITLE
Fix Volume Serial Number verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             flags: -DCMAKE_TOOLCHAIN_FILE=cmake/DOS-GCC-IA16.cmake
           - name: Linux
             target: linux
-            apts: gcc-mingw-w64-x86-64 libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libfluidsynth-dev
+            apts: gcc-mingw-w64-x86-64 libsdl2-dev libsdl2-ttf-dev libfontconfig-dev libfluidsynth-dev libblkid-dev
           - name: Windows (IA-32)
             target: windows-ia32
             apts: gcc-mingw-w64-i686

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is still work in progress, but I'm doing my best to separate working versio
 Building requires x86_64 Linux with *CMake*, *GNU Make*, *GNU Binutils*, and `zip`.
 Both Windows and Linux builds rely on *SDL2* and *SDL2_ttf* libraries.
 Windows target is built using *MinGW-w64* for i686 or x86_64.
-Linux build requires Fontconfig and FluidSynth.
+Linux build requires Fontconfig, FluidSynth, and libblkid.
 MS-DOS builds require [GCC for IA-16](https://github.com/tkchia/gcc-ia16/) with [libi86](https://github.com/tkchia/libi86/).
 Script encryption tools are written in *Python 3*.
 

--- a/inc/api/dos.h
+++ b/inc/api/dos.h
@@ -31,15 +31,4 @@ dos_exit(int code)
         ;
 }
 
-static inline unsigned
-dos_read_disk(uint8_t drive, uint16_t sectors, uint16_t start, char *buffer)
-{
-    unsigned short ax;
-    asm volatile("int $0x25; popf"
-                 : "=a"(ax)
-                 : "Ral"(drive), "c"(sectors), "d"(start), "b"(buffer)
-                 : "memory");
-    return ax;
-}
-
 #endif // _API_DOS_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ if(WIN32)
 endif()
 
 if(LINUX)
+    target_link_libraries(lavender blkid)
     target_link_libraries(lavender ${Fontconfig_LIBRARIES})
     target_link_libraries(lavender ${SDL2_LIBRARIES} SDL2_ttf)
     target_link_libraries(lavender fluidsynth)

--- a/src/pal/linux.c
+++ b/src/pal/linux.c
@@ -1,7 +1,11 @@
+#include <linux/limits.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <time.h>
 #include <unistd.h>
 
 #include <SDL2/SDL.h>
+#include <blkid/blkid.h>
 #include <fontconfig/fontconfig.h>
 
 #include <fmt/exe.h>
@@ -94,7 +98,71 @@ uint32_t
 pal_get_medium_id(const char *tag)
 {
     LOG("entry");
-    return 0;
+    unsigned volume_sn_high = 0, volume_sn_low = 0;
+
+    char self[PATH_MAX];
+    if (0 > readlink("/proc/self/exe", self, PATH_MAX))
+    {
+        LOG("exit, cannot retrieve executable path!");
+        return 0;
+    }
+
+    struct stat info;
+    if (0 > stat(self, &info))
+    {
+        LOG("exit, cannot get file info for '%s'!", self);
+        return 0;
+    }
+
+    blkid_cache cache;
+    if (0 > blkid_get_cache(&cache, NULL))
+    {
+        LOG("exit, cannot get blkid cache!");
+        return 0;
+    }
+
+    char *devname = blkid_devno_to_devname(info.st_dev);
+    if (NULL == devname)
+    {
+        LOG("exit, cannot get devname for %d:%d!", major(info.st_dev),
+            minor(info.st_dev));
+        return 0;
+    }
+
+    const char *label = blkid_get_tag_value(cache, "LABEL", devname);
+    if (NULL == label)
+    {
+        LOG("cannot get label of '%s'!", devname);
+        goto end;
+    }
+
+    if (0 != strcmp(tag, label))
+    {
+        LOG("label '%s' not matching '%s'", label, tag);
+        goto end;
+    }
+
+    const char *uuid = blkid_get_tag_value(cache, "UUID", devname);
+    if (NULL == uuid)
+    {
+        LOG("cannot get UUID of '%s'!", devname);
+        goto end;
+    }
+
+    LOG("dev %d:%d [%s] '%s' - uuid: %s", major(info.st_dev),
+        minor(info.st_dev), devname, label, uuid);
+
+    if (2 != sscanf(uuid, "%04X-%04X", &volume_sn_high, &volume_sn_low))
+    {
+        LOG("unknown volume serial number format!");
+        volume_sn_high = volume_sn_low = 0;
+        goto end;
+    }
+
+end:
+    LOG("exit, %04X-%04X", volume_sn_high, volume_sn_low);
+    free(devname);
+    return (volume_sn_high << 16) | volume_sn_low;
 }
 
 int

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -248,7 +248,46 @@ uint32_t
 pal_get_medium_id(const char *tag)
 {
     LOG("entry");
-    return 0;
+    DWORD volume_sn;
+
+    wchar_t self[MAX_PATH];
+    if (0 == GetModuleFileNameW(NULL, self, MAX_PATH))
+    {
+        LOG("cannot retrieve executable path!");
+        goto end;
+    }
+
+    wchar_t volume_path[MAX_PATH];
+    if (!GetVolumePathNameW(self, volume_path, MAX_PATH))
+    {
+        LOG("cannot get volume path for '%ls'!", self);
+        goto end;
+    }
+
+    wchar_t volume_name[MAX_PATH];
+    if (!GetVolumeInformationW(volume_path, volume_name, MAX_PATH, &volume_sn,
+                               NULL, NULL, NULL, 0))
+    {
+        LOG("cannot get volume information for '%ls'!", volume_path);
+        goto end;
+    }
+
+    wchar_t wide_tag[12];
+    if (0 == MultiByteToWideChar(CP_OEMCP, 0, tag, -1, wide_tag, 12))
+    {
+        LOG("cannot widen tag '%s'!", tag);
+        goto end;
+    }
+
+    if (0 != wcscmp(wide_tag, volume_name))
+    {
+        LOG("volume name '%ls' not matching '%ls'!", volume_name, wide_tag);
+        goto end;
+    }
+
+end:
+    LOG("exit, %04X-%04X", HIWORD(volume_sn), LOWORD(volume_sn));
+    return (uint32_t)volume_sn;
 }
 
 int


### PR DESCRIPTION
- use BIOS call instead of DOS for disk read - fixes #92 
- add volume serial number retrieval for Windows and Linux - fixes #147 