### PR TITLE
Utilize timer events under Windows

### DIFF
--- a/inc/pal.h
+++ b/inc/pal.h
@@ -81,6 +81,11 @@ pal_get_ticks(unsigned ms);
 extern void ddcall
 pal_sleep(unsigned ms);
 
+#if PAL_EXTERNAL_TICK
+extern void
+pal_stall(int ms);
+#endif
+
 extern int
 pal_enum_assets(pal_enum_assets_callback callback,
                 const char              *pattern,

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -9,6 +9,12 @@ DEFINE_HANDLE(hasset);
 
 typedef bool (*pal_enum_assets_callback)(const char *, void *);
 
+#if defined(_WIN32)
+#define PAL_EXTERNAL_TICK 1
+#else
+#define PAL_EXTERNAL_TICK 0
+#endif
+
 #define PAL_MOUSE_LBUTTON 0x0001
 #define PAL_MOUSE_RBUTTON 0x0002
 

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -96,7 +96,9 @@ sld_handle(void)
         return;
     }
 
+#if !PAL_EXTERNAL_TICK
     snd_handle();
+#endif
 
     sld_context *ctx = __sld_ctx;
     if (NULL == __sld_ctx)

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -32,6 +32,9 @@ _execute_entry(sld_entry *sld)
     case SLD_TYPE_PLAY:
         return __sld_execute_play(sld);
     case SLD_TYPE_WAITKEY:
+#if PAL_EXTERNAL_TICK
+        pal_stall(-1);
+#endif
         pal_enable_mouse();
         __sld_ctx->state = SLD_STATE_WAIT;
         return 0;
@@ -169,6 +172,9 @@ sld_handle(void)
 
         ctx->offset += length;
 
+#if PAL_EXTERNAL_TICK
+        pal_stall(ctx->entry.delay / 4);
+#endif
         if (0 != ctx->entry.delay)
         {
             ctx->next_step =


### PR DESCRIPTION
PAL:
- use `WM_TIMER` message - reduces CPU usage tenfold
- allow timing control

SND:
- use multimedia timers for MIDI playback control - fixes #165 

SLD:
- use Windows PAL timing control