### PR TITLE
Fix building of non-Windows targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
     add_binary_object(version version.bin _binary_obj_version_txt)
     target_link_binary_object(lavender version)
 
-    add_win32_strings(strings resource.ENU.rc)
+    add_win32_strings(strings resource.${LAV_LANG}.rc)
     target_link_win32_strings(lavender strings)
 endif()
 

--- a/src/snd/CMakeLists.txt
+++ b/src/snd/CMakeLists.txt
@@ -8,12 +8,12 @@ if(CONFIG_SOUND)
     target_sources(snd PRIVATE fspk.c)
 
     if(DOS)
-        target_sources(snd PRIVATE gm-opl2.c)
-        target_sources(snd PRIVATE dmpu401.c)
-        target_sources(snd PRIVATE dopl2.c)
         target_sources(snd PRIVATE dbeep.c)
-
-        if(NOT DOS_TARGET_COM)
+        if(DOS_TARGET_COM)
+            target_sources(snd PRIVATE dmpu401.c)
+            target_sources(snd PRIVATE gm-opl2.c)
+            target_sources(snd PRIVATE dopl2.c)
+        else()
             add_driver(sndmpu)
             target_sources(sndmpu PRIVATE dmpu401.c)
 


### PR DESCRIPTION
- reenable non-English translations on non-Windows targets - fixes #178 
- remove duplicate sound drivers from the main executable - fixes #179 