### PR TITLE
Add display scaling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This is still work in progress, but I'm doing my best to separate working versio
 * graphics mode
   * CGA 640x200 monochrome under DOS
   * EGA 640x350 16-color under DOS using a loadable driver
-  * 24-bit RGB under Windows and Linux 
+  * 24-bit RGB under Windows and Linux with user-customizable content size
+  * Windows DPI awareness support
 * display delays (animations)
   * millisecond resolution
 * displaying text (with UTF-8 subset support)

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -130,6 +130,10 @@ gfx_get_glyph_dimensions(gfx_dimensions *dim);
 extern uint16_t
 gfx_get_pixel_aspect(void);
 
+// Get display scaling factor
+extern float
+gfx_get_scale(void);
+
 #if defined(__ia16__)
 extern bool
 gfx_get_font_data(gfx_glyph_data *data);

--- a/inc/platform/sdl2arch.h
+++ b/inc/platform/sdl2arch.h
@@ -15,4 +15,7 @@ sdl2arch_get_font(void);
 extern void
 sdl2arch_set_window_title(const char *title);
 
+extern bool
+sdl2arch_set_scale(int scale);
+
 #endif // _PLATFORM_SDL2ARCH_H_

--- a/inc/platform/windows.h
+++ b/inc/platform/windows.h
@@ -20,6 +20,9 @@ windows_set_window_title(const char *title);
 
 extern HDC
 windows_get_dc(void);
+
+extern bool
+windows_set_scale(float scale);
 #endif
 
 #endif // _PLATFORM_WINDOWS_H_

--- a/src/dlg/fullscrn.c
+++ b/src/dlg/fullscrn.c
@@ -80,13 +80,15 @@ _draw_frame(int columns, int lines, const char *title, int title_length)
                            window.width - 1, 1};
     gfx_draw_line(&title_line, GFX_COLOR_BLACK);
 
-    gfx_rect stripe = {window.left + window.width - 4, window.top + 1,
+    int      scale = (_glyph.width + 7) / 8;
+    gfx_rect stripe = {window.left + window.width - 4,
+                       window.top + (scale + 1) / 2,
                        (window.width - ((title_length + 6) * _glyph.width)), 1};
     stripe.left -= stripe.width;
-    for (int i = 0; i < _glyph.height; i += 2)
+    for (int i = 0; i < _glyph.height; i += 2 * scale)
     {
         gfx_draw_line(&stripe, GFX_COLOR_BLACK);
-        stripe.top += 2;
+        stripe.top += 2 * scale;
     }
 
 #ifdef UTF8_NATIVE

--- a/src/dlg/windows.c
+++ b/src/dlg/windows.c
@@ -64,14 +64,15 @@ dlg_refresh(const gfx_rect *clip)
     };
     GradientFill(dc, vertex, lengthof(vertex), &mesh, 1, GRADIENT_FILL_RECT_V);
 
+    float scale = gfx_get_scale();
     if (NULL == _font_banner)
     {
         _font_banner =
-            CreateFontW(32, 0, 0, 0, FW_BOLD, TRUE, FALSE, FALSE,
+            CreateFontW(scale * 32, 0, 0, 0, FW_BOLD, TRUE, FALSE, FALSE,
                         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
                         CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, FF_ROMAN, NULL);
         _font_footer =
-            CreateFontW(12, 0, 0, 0, FW_REGULAR, FALSE, FALSE, FALSE,
+            CreateFontW(scale * 12, 0, 0, 0, FW_REGULAR, FALSE, FALSE, FALSE,
                         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
                         CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, FF_SWISS, NULL);
         atexit(_free_fonts);
@@ -94,8 +95,8 @@ dlg_refresh(const gfx_rect *clip)
     DrawTextW(dc, banner, -1, &rect, 0);
 
     SetTextColor(dc, 0xFFFFFF);
-    rect.left -= 2;
-    rect.top -= 2;
+    rect.left -= scale * 2;
+    rect.top -= scale * 2;
     DrawTextW(dc, banner, -1, &rect, DT_SINGLELINE);
 
     // Footer
@@ -344,6 +345,8 @@ _dialog_proc(HWND dlg, UINT message, WPARAM wparam, LPARAM lparam)
 static HWND
 _create_prompt(LPCWSTR title, LPCWSTR message)
 {
+    int dpi = GetDeviceCaps(windows_get_dc(), LOGPIXELSY);
+
     // Dialog box
     LPDLGTEMPLATEW dt = (LPDLGTEMPLATEW)GlobalLock(_hgbl);
     ZeroMemory(dt, 1024);
@@ -366,7 +369,7 @@ _create_prompt(LPCWSTR title, LPCWSTR message)
 
     // font size
     LPWORD font_size = (LPWORD)(caption + caption_length);
-    *font_size = _nclm.lfMessageFont.lfHeight;
+    *font_size = MulDiv(_nclm.lfMessageFont.lfHeight, 96, dpi);
 
     // font face
     LPWSTR font_face = (LPWSTR)(font_size + 1);

--- a/src/dlg/windows.c
+++ b/src/dlg/windows.c
@@ -1,5 +1,6 @@
 #include <windows.h>
 
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -14,6 +15,7 @@
 
 static HGLOBAL           _hgbl = NULL;
 static NONCLIENTMETRICSW _nclm = {0};
+static float             _scale = 1.f;
 
 static HHOOK   _hook = NULL;
 static WNDPROC _prev_wnd_proc = NULL;
@@ -65,6 +67,15 @@ dlg_refresh(const gfx_rect *clip)
     GradientFill(dc, vertex, lengthof(vertex), &mesh, 1, GRADIENT_FILL_RECT_V);
 
     float scale = gfx_get_scale();
+    if ((0.05 < fabsf(_scale - scale)) && (NULL != _font_banner))
+    {
+        DeleteObject(_font_banner);
+        DeleteObject(_font_footer);
+        _font_banner = NULL;
+        _font_footer = NULL;
+    }
+
+    _scale = scale;
     if (NULL == _font_banner)
     {
         _font_banner =

--- a/src/gfx/dosddi.c
+++ b/src/gfx/dosddi.c
@@ -91,6 +91,12 @@ gfx_get_glyph_dimensions(gfx_dimensions *dim)
     gfx_device_get_property(_dev, GFX_PROPERTY_GLYPH_SIZE, dim);
 }
 
+float
+gfx_get_scale(void)
+{
+    return 1.f;
+}
+
 bool
 gfx_get_font_data(gfx_glyph_data *data)
 {

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -29,13 +29,38 @@ static const COLORREF COLORS[] = {[GFX_COLOR_BLACK] = RGB(0, 0, 0),
                                   [GFX_COLOR_YELLOW] = RGB(255, 255, 0),
                                   [GFX_COLOR_WHITE] = RGB(255, 255, 255)};
 
+static const wchar_t *FONT_NAMES[] = {
+    L"Cascadia Code",  // Windows 11
+    L"Consolas",       // Windows Vista
+    L"Lucida Console", // Windows 2000
+    NULL               // usually Courier New
+};
+
+static HFONT
+_get_font(void)
+{
+    HFONT font = NULL;
+
+    for (int i = 0; i < lengthof(FONT_NAMES); i++)
+    {
+        font = CreateFontW(_scale * 16, 0, 0, 0, FW_REGULAR, FALSE, FALSE,
+                           FALSE, DEFAULT_CHARSET, OUT_TT_PRECIS,
+                           CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY,
+                           FIXED_PITCH | FF_MODERN, FONT_NAMES[i]);
+        if (NULL != font)
+        {
+            break;
+        }
+    }
+
+    return font;
+}
+
 bool
 gfx_initialize(void)
 {
     _scale = 1.0f;
-    _font = CreateFontW(_scale * 16, 0, 0, 0, FW_REGULAR, FALSE, FALSE, FALSE,
-                        DEFAULT_CHARSET, OUT_TT_PRECIS, CLIP_DEFAULT_PRECIS,
-                        ANTIALIASED_QUALITY, FIXED_PITCH | FF_MODERN, NULL);
+    _font = _get_font();
     _wnd = windows_get_hwnd();
 
     HDC wnd_dc = GetDC(_wnd);

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -121,6 +121,12 @@ gfx_get_pixel_aspect(void)
     return 64 * 1;
 }
 
+float
+gfx_get_scale(void)
+{
+    return _scale;
+}
+
 unsigned
 gfx_get_color_depth(void)
 {

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -228,9 +228,10 @@ gfx_draw_bitmap(gfx_bitmap *bm, int x, int y)
     }
 
     SelectObject(bmp_dc, bmp);
-    BitBlt(_dc, x, y, bm->width, abs(bm->height), bmp_dc, 0, 0, SRCCOPY);
+    StretchBlt(_dc, x, y, _scale * bm->width, _scale * abs(bm->height), bmp_dc,
+               0, 0, bm->width, abs(bm->height), SRCCOPY);
 
-    RECT rect = {x, y, x + bm->width, y + abs(bm->height)};
+    RECT rect = {x, y, x + _scale * bm->width, y + _scale * abs(bm->height)};
     InvalidateRect(_wnd, &rect, FALSE);
 
 end:

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -59,11 +59,12 @@ _get_font(void)
 bool
 gfx_initialize(void)
 {
-    _scale = 1.0f;
     _font = _get_font();
     _wnd = windows_get_hwnd();
 
     HDC wnd_dc = GetDC(_wnd);
+    _scale = (float)GetDeviceCaps(wnd_dc, LOGPIXELSX) / 96.f;
+
     _dc = CreateCompatibleDC(wnd_dc);
     if (NULL == _dc)
     {

--- a/src/gfx/sdl2.c
+++ b/src/gfx/sdl2.c
@@ -100,9 +100,10 @@ gfx_initialize(void)
     LOG("font: '%s'", font_path);
     TTF_SizeText(_font, "WW", &_font_w, &_font_h);
     _font_w /= 2;
+    _font_h = TTF_FontHeight(_font);
 
     _screen_w = 80 * _font_w;
-    _screen_h = 25 * 16;
+    _screen_h = 25 * _font_h;
     _window = SDL_CreateWindow(pal_get_version_string(), SDL_WINDOWPOS_CENTERED,
                                SDL_WINDOWPOS_CENTERED, _screen_w, _screen_h,
                                SDL_WINDOW_SHOWN);
@@ -163,7 +164,7 @@ void
 gfx_get_glyph_dimensions(gfx_dimensions *dim)
 {
     dim->width = _font_w;
-    dim->height = 16;
+    dim->height = _font_h;
 }
 
 uint16_t
@@ -327,7 +328,7 @@ gfx_draw_text(const char *str, uint16_t x, uint16_t y)
 
     SDL_Surface *surface =
         TTF_RenderUTF8_Blended(_font, str, COLORS[GFX_COLOR_WHITE]);
-    SDL_Rect rect = {x * _font_w, y * 16, surface->w, surface->h};
+    SDL_Rect rect = {x * _font_w, y * _font_h, surface->w, surface->h};
 
     if (!_rendering_text)
     {

--- a/src/gfx/sdl2.c
+++ b/src/gfx/sdl2.c
@@ -180,6 +180,12 @@ gfx_get_pixel_aspect(void)
     return ratio;
 }
 
+float
+gfx_get_scale(void)
+{
+    return 1.f;
+}
+
 unsigned
 gfx_get_color_depth(void)
 {

--- a/src/lavender.exe.manifest
+++ b/src/lavender.exe.manifest
@@ -7,4 +7,9 @@
             <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
         </dependentAssembly>
     </dependency>
+    <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
 </assembly>

--- a/src/pal/sdl2arch.c
+++ b/src/pal/sdl2arch.c
@@ -87,7 +87,7 @@ pal_handle(void)
     case SDL_MOUSEMOTION: {
         LOG("mouse x: %d, y: %d", e.motion.x, e.motion.y);
         _mouse_x = e.motion.x / _mouse_cell.width;
-        _mouse_y = e.motion.y / 16;
+        _mouse_y = e.motion.y / _mouse_cell.height;
         break;
     }
 

--- a/src/pal/sdl2arch.c
+++ b/src/pal/sdl2arch.c
@@ -75,6 +75,25 @@ pal_handle(void)
 
     case SDL_KEYDOWN: {
         LOG("key '%s' down", SDL_GetKeyName(e.key.keysym.sym));
+        if (KMOD_CTRL & e.key.keysym.mod)
+        {
+            if ((SDLK_PLUS == e.key.keysym.sym) ||
+                (SDLK_KP_PLUS == e.key.keysym.sym))
+            {
+                sdl2arch_set_scale(gfx_get_scale() + 1);
+                gfx_get_glyph_dimensions(&_mouse_cell);
+                break;
+            }
+
+            if ((SDLK_MINUS == e.key.keysym.sym) ||
+                (SDLK_KP_MINUS == e.key.keysym.sym))
+            {
+                sdl2arch_set_scale(gfx_get_scale() - 1);
+                gfx_get_glyph_dimensions(&_mouse_cell);
+                break;
+            }
+        }
+
         _keycode = e.key.keysym.sym;
         break;
     }

--- a/src/resource.CSY.rc
+++ b/src/resource.CSY.rc
@@ -40,6 +40,10 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
     IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nZpřístupněno pod Licencí MIT."
     IDS_ABOUT, "O programu..."
     IDS_ABOUT_LONG, "O programu Lavender"
+
+#ifdef _WIN32
+    IDS_SIZE, "Rozměr"
+#endif
 }
 
 #ifndef STRINGS_ONLY

--- a/src/resource.ENU.rc
+++ b/src/resource.ENU.rc
@@ -40,6 +40,10 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
     IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nShared under the MIT License."
     IDS_ABOUT, "About..."
     IDS_ABOUT_LONG, "About Lavender"
+
+#ifdef _WIN32
+    IDS_SIZE, "Size"
+#endif
 }
 
 #ifndef STRINGS_ONLY

--- a/src/resource.PLK.rc
+++ b/src/resource.PLK.rc
@@ -40,6 +40,10 @@ LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
     IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nUdostępniono na zasadach Licencji MIT."
     IDS_ABOUT, "O programie..."
     IDS_ABOUT_LONG, "O programie Lavender"
+
+#ifdef _WIN32
+    IDS_SIZE, "Rozmiar"
+#endif
 }
 
 #ifndef STRINGS_ONLY

--- a/src/resource.h
+++ b/src/resource.h
@@ -43,3 +43,7 @@
 #define IDS_COPYRIGHT   0x41
 #define IDS_ABOUT       0x42
 #define IDS_ABOUT_LONG  0x43
+
+#ifdef _WIN32
+#define IDS_SIZE 0x50
+#endif

--- a/src/sld/bitmap.c
+++ b/src/sld/bitmap.c
@@ -66,12 +66,13 @@ __sld_execute_bitmap(sld_entry *sld)
 
     gfx_dimensions screen;
     gfx_get_screen_dimensions(&screen);
+    float scale = gfx_get_scale();
 
     int x, y;
     switch (sld->posx)
     {
     case SLD_ALIGN_CENTER:
-        x = (screen.width - bm.width) / 2;
+        x = ((float)screen.width / scale - bm.width) / 2 * scale;
         break;
     case SLD_ALIGN_RIGHT:
         x = screen.width - bm.width;

--- a/src/sld/bitmap.c
+++ b/src/sld/bitmap.c
@@ -78,10 +78,10 @@ __sld_execute_bitmap(sld_entry *sld)
         x = screen.width - bm.width;
         break;
     default:
-        x = (int)((int32_t)sld->posx * __sld_screen.width / SLD_VIEWBOX_WIDTH);
+        x = (int)((int32_t)sld->posx * screen.width / SLD_VIEWBOX_WIDTH);
     }
 
-    y = (int)((int32_t)sld->posy * __sld_screen.height / SLD_VIEWBOX_HEIGHT);
+    y = (int)((int32_t)sld->posy * screen.height / SLD_VIEWBOX_HEIGHT);
 
     if (!gfx_draw_bitmap(&bm, x, y))
     {

--- a/src/sld/shape.c
+++ b/src/sld/shape.c
@@ -10,12 +10,15 @@ typedef struct
 static void
 _translate(uint16_t *x, uint16_t *y, gfx_dimensions *dims)
 {
+    gfx_dimensions screen;
+    gfx_get_screen_dimensions(&screen);
+
     int32_t w = dims->width;
     int32_t h = dims->height;
-    int32_t xend = ((int32_t)*x + w) * __sld_screen.width / SLD_VIEWBOX_WIDTH;
-    int32_t yend = ((int32_t)*y + h) * __sld_screen.height / SLD_VIEWBOX_HEIGHT;
-    *x = (uint16_t)((int32_t)*x * __sld_screen.width / SLD_VIEWBOX_WIDTH);
-    *y = (uint16_t)((int32_t)*y * __sld_screen.height / SLD_VIEWBOX_HEIGHT);
+    int32_t xend = ((int32_t)*x + w) * screen.width / SLD_VIEWBOX_WIDTH;
+    int32_t yend = ((int32_t)*y + h) * screen.height / SLD_VIEWBOX_HEIGHT;
+    *x = (uint16_t)((int32_t)*x * screen.width / SLD_VIEWBOX_WIDTH);
+    *y = (uint16_t)((int32_t)*y * screen.height / SLD_VIEWBOX_HEIGHT);
     dims->width = xend - *x;
     dims->height = yend - *y;
 }


### PR DESCRIPTION
Closes #163 

SDL2:
- support variable line height
- support scaling
- scale bitmaps
- allow the user to change the scaling factor using the keyboard

Windows:
- support scaling
- select the best font
- add DPI awareness
- scale bitmaps
- allow the user to change the scaling factor using the keyboard, the system menu, and the context menu

DLG:
- make frame stripes scaling aware

SLD:
- use current screen dimensions for coordinate translation