### PR TITLE
Add support for fullscreen mode under Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is still work in progress, but I'm doing my best to separate working versio
   * CGA 640x200 monochrome under DOS
   * EGA 640x350 16-color under DOS using a loadable driver
   * 24-bit RGB under Windows and Linux with user-customizable content size
-  * Windows DPI awareness support
+  * Windows DPI awareness and full screen mode support
 * display delays (animations)
   * millisecond resolution
 * displaying text (with UTF-8 subset support)

--- a/inc/platform/windows.h
+++ b/inc/platform/windows.h
@@ -21,6 +21,12 @@ windows_set_window_title(const char *title);
 extern HDC
 windows_get_dc(void);
 
+extern HFONT
+windows_find_font(int max_width, int max_height);
+
+extern bool
+windows_set_font(HFONT font);
+
 extern bool
 windows_set_scale(float scale);
 

--- a/inc/platform/windows.h
+++ b/inc/platform/windows.h
@@ -23,6 +23,12 @@ windows_get_dc(void);
 
 extern bool
 windows_set_scale(float scale);
+
+extern void
+windows_set_box(int width, int height);
+
+extern void
+windows_get_origin(POINT *origin);
 #endif
 
 #endif // _PLATFORM_WINDOWS_H_

--- a/inc/platform/windows.h
+++ b/inc/platform/windows.h
@@ -29,6 +29,9 @@ windows_set_box(int width, int height);
 
 extern void
 windows_get_origin(POINT *origin);
+
+extern COLORREF
+windows_get_bg(void);
 #endif
 
 #endif // _PLATFORM_WINDOWS_H_

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <windows.h>
 
 #include <gfx.h>
@@ -33,43 +34,14 @@ static const COLORREF COLORS[] = {[GFX_COLOR_BLACK] = RGB(0, 0, 0),
                                   [GFX_COLOR_YELLOW] = RGB(255, 255, 0),
                                   [GFX_COLOR_WHITE] = RGB(255, 255, 255)};
 
-static const wchar_t *FONT_NAMES[] = {
-    L"Cascadia Code",  // Windows 11
-    L"Consolas",       // Windows Vista
-    L"Lucida Console", // Windows 2000
-    NULL               // usually Courier New
-};
-
-static HFONT
-_get_font(void)
-{
-    HFONT font = NULL;
-
-    for (int i = 0; i < lengthof(FONT_NAMES); i++)
-    {
-        font = CreateFontW(_scale * 16, 0, 0, 0, FW_REGULAR, FALSE, FALSE,
-                           FALSE, DEFAULT_CHARSET, OUT_TT_PRECIS,
-                           CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY,
-                           FIXED_PITCH | FF_MODERN, FONT_NAMES[i]);
-        if (NULL != font)
-        {
-            break;
-        }
-    }
-
-    return font;
-}
-
 bool
-windows_set_scale(float scale)
+windows_set_font(HFONT font)
 {
-    _scale = max(scale, _min_scale);
-
     if (NULL != _font)
     {
         DeleteObject(_font);
     }
-    _font = _get_font();
+    _font = font;
 
     HDC wnd_dc = GetDC(_wnd);
     HDC new_dc = CreateCompatibleDC(wnd_dc);
@@ -92,6 +64,7 @@ windows_set_scale(float scale)
     _screen.cy = 25 * _glyph.cy;
     _origin.x = 0;
     _origin.y = 0;
+    _scale = (float)metric.tmHeight / 16.f;
 
     RECT rect;
     GetClientRect(_wnd, &rect);
@@ -126,6 +99,12 @@ windows_set_scale(float scale)
     RedrawWindow(_wnd, NULL, NULL, RDW_FRAME | RDW_INVALIDATE);
 
     return true;
+}
+
+bool
+windows_set_scale(float scale)
+{
+    return windows_set_font(windows_find_font(-1, roundf(scale * 16.f)));
 }
 
 bool

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -430,6 +430,11 @@ _wnd_proc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         {
             HDC src_dc = windows_get_dc();
 
+            RECT wnd_rect;
+            GetClientRect(wnd, &wnd_rect);
+            SetDCBrushColor(dc, windows_get_bg());
+            FillRect(dc, &ps.rcPaint, GetStockObject(DC_BRUSH));
+
             POINT origin;
             windows_get_origin(&origin);
             BitBlt(dc, ps.rcPaint.left, ps.rcPaint.top,

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -39,6 +39,7 @@
 
 #define ID_ABOUT 0x1000
 #define ID_SCALE 0x2000
+#define ID_FULL  0x2100
 
 // See DEVICE_SCALE_FACTOR in shtypes.h
 static const float SCALES[] = {1.00f, 1.20f, 1.25f, 1.40f, 1.50f, 1.60f,
@@ -336,6 +337,8 @@ _toggle_fullscreen(HWND wnd)
     gfx_get_glyph_dimensions(&_mouse_cell);
     _fullscreen = !_fullscreen;
 
+    CheckMenuItem(_size_menu, ID_FULL,
+                  MF_BYCOMMAND | (_fullscreen ? MF_CHECKED : MF_UNCHECKED));
     for (int i = _min_scale_id - ID_SCALE; i < lengthof(SCALES); i++)
     {
         EnableMenuItem(_size_menu, ID_SCALE + i,
@@ -359,6 +362,11 @@ _wnd_proc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             HDC   wnd_dc = GetDC(_wnd);
             float min_scale = (float)GetDeviceCaps(wnd_dc, LOGPIXELSX) / 96.f;
             ReleaseDC(_wnd, wnd_dc);
+
+            LoadStringW(_instance, IDS_FULL, str, lengthof(str));
+            AppendMenuW(_size_menu, MF_STRING, ID_FULL, str);
+
+            AppendMenuW(_size_menu, MF_SEPARATOR, 0, NULL);
 
             for (size_t i = 0; i < lengthof(SCALES); i++)
             {
@@ -425,6 +433,12 @@ _wnd_proc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             ((ID_SCALE + lengthof(SCALES)) > LOWORD(wparam)))
         {
             _set_scale(LOWORD(wparam) - ID_SCALE);
+            return 0;
+        }
+
+        if (ID_FULL == LOWORD(wparam))
+        {
+            _toggle_fullscreen(wnd);
             return 0;
         }
 

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -429,10 +429,14 @@ _wnd_proc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         if (!dlg_refresh(&clip))
         {
             HDC src_dc = windows_get_dc();
+
+            POINT origin;
+            windows_get_origin(&origin);
             BitBlt(dc, ps.rcPaint.left, ps.rcPaint.top,
                    ps.rcPaint.right - ps.rcPaint.left,
-                   ps.rcPaint.bottom - ps.rcPaint.top, src_dc, ps.rcPaint.left,
-                   ps.rcPaint.top, SRCCOPY);
+                   ps.rcPaint.bottom - ps.rcPaint.top, src_dc,
+                   ps.rcPaint.left - origin.x, ps.rcPaint.top - origin.y,
+                   SRCCOPY);
         }
 
         EndPaint(wnd, &ps);

--- a/src/resource.CSY.rc
+++ b/src/resource.CSY.rc
@@ -43,6 +43,7 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 
 #ifdef _WIN32
     IDS_SIZE, "Rozměr"
+    IDS_FULL, "&Celá obrazovka\tF11"
 #endif
 }
 

--- a/src/resource.ENU.rc
+++ b/src/resource.ENU.rc
@@ -43,6 +43,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 #ifdef _WIN32
     IDS_SIZE, "Size"
+    IDS_FULL, "&Fullscreen\tF11"
 #endif
 }
 

--- a/src/resource.PLK.rc
+++ b/src/resource.PLK.rc
@@ -43,6 +43,7 @@ LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 
 #ifdef _WIN32
     IDS_SIZE, "Rozmiar"
+    IDS_FULL, "&Pełny ekran\tF11"
 #endif
 }
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -46,4 +46,5 @@
 
 #ifdef _WIN32
 #define IDS_SIZE 0x50
+#define IDS_FULL 0x51
 #endif


### PR DESCRIPTION
Closes #166 

GFX:
- GDI: store canvas origin and background color

Windows:
- rely on the font when setting the scale
- enter fullscreen mode using the keyboard (F11), the menu, or the command line argument (`/k`)