### PR TITLE
Fix variable access errors in fullscreen encryption UI

### DIFF
--- a/inc/base.h
+++ b/inc/base.h
@@ -29,10 +29,6 @@
 #define __builtin_parity(x) (__popcnt(x) % 2)
 
 #define strcasecmp _stricmp
-
-#ifndef alloca
-#define alloca _alloca
-#endif
 #endif
 
 #ifndef far

--- a/src/enc/ui/fullscrn.c
+++ b/src/enc/ui/fullscrn.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <string.h>
 
 #include <fmt/utf8.h>
@@ -82,18 +81,15 @@ encui_exit(void)
 }
 
 static void
-_draw_title(const char *title)
+_draw_title(char *title)
 {
     gfx_rect bar = {0, 0, _screen.width, _glyph.height + 1};
     gfx_fill_rectangle(&bar, GFX_COLOR_BLACK);
 
-#ifdef UTF8_NATIVE
-    const char *title_l = title;
-#else
-    char *title_l = alloca(strlen(title) + 1);
-    utf8_encode(title, title_l, pal_wctob);
+#ifndef UTF8_NATIVE
+    utf8_encode(title, title, pal_wctob);
 #endif
-    gfx_draw_text(title_l, 1, 0);
+    gfx_draw_text(title, 1, 0);
 }
 
 static void
@@ -206,16 +202,13 @@ _wrap(char *dst, const char *src, size_t width, char delimiter)
 }
 
 static int
-_draw_text(int top, const char *text)
+_draw_text(int top, char *text)
 {
-#ifdef UTF8_NATIVE
-    const char *text_l = text;
-#else
-    char *text_l = alloca(strlen(text) + 1);
-    utf8_encode(text, text_l, pal_wctob);
+#ifndef UTF8_NATIVE
+    utf8_encode(text, text, pal_wctob);
 #endif
 
-    const char *fragment = text_l;
+    const char *fragment = text;
 #ifdef UTF8_NATIVE
     char line_buff[2 * TEXT_WIDTH + 1];
 #else

--- a/src/enc/ui/fullscrn.c
+++ b/src/enc/ui/fullscrn.c
@@ -452,7 +452,7 @@ encui_handle(void)
         return ENCUI_INCOMPLETE;
     }
 
-    if (VK_PRIOR == scancode)
+    if ((VK_PRIOR == scancode) && (0 < _id))
     {
         _reset();
         encui_set_page(_id - 1);

--- a/src/enc/ui/fullscrn.c
+++ b/src/enc/ui/fullscrn.c
@@ -155,22 +155,23 @@ _copy_text(char *dst, const char *src, size_t length)
 static int
 _wrap(char *dst, const char *src, size_t width, char delimiter)
 {
-    int i = 0;
     int chars = 0;
 
-    while (src[i])
+    const char *psrc = src;
+    char       *pdst = dst;
+    while (*psrc && (chars <= width))
     {
-        if (delimiter == src[i])
+        if (delimiter == *psrc)
         {
-            dst[i] = 0;
-            return i + 1;
+            *pdst = 0;
+            return psrc - src + 1;
         }
 
-        size_t word_span = strcspn(src + i, " \n");
-        int    word_length = _measure_span(src + i, word_span);
+        size_t word_span = strcspn(psrc, " \n");
+        int    word_length = _measure_span(psrc, word_span);
         if (width < chars + word_length)
         {
-            if (0 == i)
+            if (src == psrc)
             {
                 return _copy_text(dst, src, width);
             }
@@ -178,20 +179,30 @@ _wrap(char *dst, const char *src, size_t width, char delimiter)
             break;
         }
 
-        memcpy(dst + i, src + i, word_span);
-        i += word_span;
+        memcpy(pdst, psrc, word_span);
+        psrc += word_span;
+        pdst += word_span;
         chars += word_length;
 
-        while (' ' == src[i])
+        while ((' ' == *psrc) && (chars < width))
         {
-            dst[i] = src[i];
-            i++;
+            *pdst = *psrc;
+            psrc++;
+            pdst++;
             chars++;
+        }
+
+        if (chars == width)
+        {
+            while (' ' == *psrc)
+            {
+                psrc++;
+            }
         }
     }
 
-    dst[i] = 0;
-    return i;
+    *pdst = 0;
+    return psrc - src;
 }
 
 static int


### PR DESCRIPTION
Closes #200 

Removed bugs:
- Prevent page index wraparound on pressing PgUp
- Prevent buffer overflow on trailing spaces when line wrapping

Improvement:
- Reuse stack allocated message buffers