### PR TITLE
Fix cleanup handling

### DIFF
--- a/src/enc/provider/prompt.c
+++ b/src/enc/provider/prompt.c
@@ -82,7 +82,7 @@ __enc_prompt_proc(int msg, enc_context *enc)
             (ENC_KEYSM_PKEY25XOR2B == (enc->provider >> 8)))
         {
             _pages[0].title = IDS_ENTERPKEY;
-            _pages[0].fields[0].data = IDS_ENTERPASS_DESC;
+            _pages[0].fields[0].data = IDS_ENTERPKEY_DESC;
             _passcode_prompt.capacity = 5 * 5 + 4;
         }
 

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -768,6 +768,8 @@ pal_cleanup(void)
         KillTimer(_wnd, 0);
     }
 
+    snd_cleanup();
+    gfx_cleanup();
     ziparch_cleanup();
 }
 

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -970,7 +970,7 @@ pal_get_machine_id(uint8_t *mid)
 
     if (ERROR_SUCCESS != RegOpenKeyExA(HKEY_LOCAL_MACHINE,
                                        "SOFTWARE\\Microsoft\\Cryptography", 0,
-                                       KEY_READ, &key))
+                                       KEY_READ | KEY_WOW64_64KEY, &key))
     {
         return false;
     }

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -96,7 +96,7 @@ sld_handle(void)
     sld_context *ctx = __sld_ctx;
     int          status;
 
-    if (!pal_handle())
+    if ((SLD_QUIT != ctx->state) && !pal_handle())
     {
         __sld_ctx->state = SLD_QUIT;
         return;


### PR DESCRIPTION
ENC:
- restore the proper description message for an access key

SLD:
- propagate quit request state - fixes #213

Windows:
- cleanup sound and graphics
- enable machine identification under WoW64 (bypass WoW64 Registry redirection)