### PR TITLE
Use non-allocating asset extraction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,6 @@ jobs:
           
       - name: Prepare archives
         run: |
-          cd lavender-dos-ia16-com  && zip -r ../lavender-${{ github.ref_name }}-dos-com.zip       * && cd ..
           cd lavender-dos-ia16-exe  && zip -r ../lavender-${{ github.ref_name }}-dos-exe.zip       * && cd ..
           cd lavender-windows-ia32  && zip -r ../lavender-${{ github.ref_name }}-windows-ia32.zip  * && cd ..
           cd lavender-windows-x64   && zip -r ../lavender-${{ github.ref_name }}-windows-x64.zip   * && cd ..
@@ -170,7 +169,6 @@ jobs:
           name: Version ${{ github.ref_name }}
           body_path: lavender-dos-ia16-com/RELEASE.md
           files: |
-            lavender-${{ github.ref_name }}-dos-com.zip
             lavender-${{ github.ref_name }}-dos-exe.zip
             lavender-${{ github.ref_name }}-windows-ia32.zip
             lavender-${{ github.ref_name }}-windows-x64.zip

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -2,6 +2,7 @@
 #define _FMT_ZIP_H_
 
 #include <assert.h>
+#include <stdio.h>
 
 #include <base.h>
 
@@ -194,6 +195,10 @@ zip_get_data(off_t olfh);
 // Dispose ZIP file data
 extern void
 zip_free_data(char *data);
+
+// Write file data to a file
+bool
+zip_extract_data(off_t olfh, FILE *out);
 
 // Get ZIP file size
 extern uint32_t


### PR DESCRIPTION
FMT:
- add helper routine for ZIP local file header processing
- add non-allocating ZIP file data extraction routine

REPO:
- temporarily exclude DOS COM build from releases

ZIPARCH:
- use non-allocating file data extraction - closes #217