### PR TITLE
Omit KEY_WOW64_64KEY flag on Windows versions older than XP

### DIFF
--- a/data/slides.txt
+++ b/data/slides.txt
@@ -12,7 +12,7 @@
 500     B   40  ^lavndr<>.pbm
 :VersionInfo
 500     T   19  ^Version 0.5
-500     T   23  ^Copyright (c) Mateusz Karcz, 2021-2024. Shared under the MIT License.
+500     T   23  ^Copyright (c) Mateusz Karcz, 2021-2025. Shared under the MIT License.
 0       K
 0       =   50  ExtendedFont
 0       =   51  Rectangles

--- a/src/enc/ui/direct/frame.cpp
+++ b/src/enc/ui/direct/frame.cpp
@@ -45,7 +45,7 @@ encui_direct_init_frame(void)
 
     gfx_draw_text(pal_get_version_string(), 1, 22);
     gfx_draw_text("https://celones.pl/lavender", 1, 23);
-    gfx_draw_text("(C) 2021-2024 Mateusz Karcz", 1, 24);
+    gfx_draw_text("(C) 2021-2025 Mateusz Karcz", 1, 24);
 
     _next.move(GFX_COLUMNS - 22, GFX_LINES - 3);
     _cancel.move(GFX_COLUMNS - 11, GFX_LINES - 3);

--- a/src/pal/windows.c
+++ b/src/pal/windows.c
@@ -968,9 +968,15 @@ pal_get_machine_id(uint8_t *mid)
     DWORD       size = sizeof(buffer);
     DWORD       type = 0;
 
+#if WINVER >= 0x0501
+    REGSAM wow64_key = KEY_WOW64_64KEY;
+#else
+    WORD   version = __builtin_bswap16(LOWORD(GetVersion()));
+    REGSAM wow64_key = (0x0501 <= version) ? KEY_WOW64_64KEY : 0;
+#endif
     if (ERROR_SUCCESS != RegOpenKeyExA(HKEY_LOCAL_MACHINE,
                                        "SOFTWARE\\Microsoft\\Cryptography", 0,
-                                       KEY_READ | KEY_WOW64_64KEY, &key))
+                                       KEY_READ | wow64_key, &key))
     {
         return false;
     }

--- a/src/resource.CSY.rc
+++ b/src/resource.CSY.rc
@@ -44,7 +44,7 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
     IDS_BADSOUND, "Neplatný nebo nepodporovaný zvukový soubor"
 
     IDS_DESCRIPTION, "Přehrávač prezentací"
-    IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nZpřístupněno pod Licencí MIT."
+    IDS_COPYRIGHT, "(C) 2021-2025 Mateusz Karcz.\nZpřístupněno pod Licencí MIT."
     IDS_ABOUT, "O programu..."
     IDS_ABOUT_LONG, "O programu Lavender"
 
@@ -81,7 +81,7 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 
 #define VER_FILEDESCRIPTION_STR     "Přehrávač prezentací Lavender"
-#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2024 Mateusz Karcz. Zpřístupněno pod Licencí MIT."
+#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2025 Mateusz Karcz. Zpřístupněno pod Licencí MIT."
 #define VER_VERSION_UNICODE_LANG    "040504B0"
 #define VER_VERSION_TRANSLATION     LCID_CSY,0x04B0
 

--- a/src/resource.ENU.rc
+++ b/src/resource.ENU.rc
@@ -44,7 +44,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
     IDS_BADSOUND, "Invalid or unsupported sound file" 
 
     IDS_DESCRIPTION, "A slideshow player"
-    IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nShared under the MIT License."
+    IDS_COPYRIGHT, "(C) 2021-2025 Mateusz Karcz.\nShared under the MIT License."
     IDS_ABOUT, "About..."
     IDS_ABOUT_LONG, "About Lavender"
 
@@ -81,7 +81,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 #define VER_FILEDESCRIPTION_STR     "Lavender slideshow player"
-#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2024 Mateusz Karcz. Shared under the MIT License."
+#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2025 Mateusz Karcz. Shared under the MIT License."
 #define VER_VERSION_UNICODE_LANG    "040904B0"
 #define VER_VERSION_TRANSLATION     LCID_ENU,0x04B0
 

--- a/src/resource.PLK.rc
+++ b/src/resource.PLK.rc
@@ -44,7 +44,7 @@ LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
     IDS_BADSOUND, "Niepoprawny lub niewspierany plik dźwiękowy"
 
     IDS_DESCRIPTION, "Odtwarzacz pokazu slajdów"
-    IDS_COPYRIGHT, "(C) 2021-2024 Mateusz Karcz.\nUdostępniono na zasadach Licencji MIT."
+    IDS_COPYRIGHT, "(C) 2021-2025 Mateusz Karcz.\nUdostępniono na zasadach Licencji MIT."
     IDS_ABOUT, "O programie..."
     IDS_ABOUT_LONG, "O programie Lavender"
 
@@ -81,7 +81,7 @@ LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 
 #define VER_FILEDESCRIPTION_STR     "Odtwarzacz pokazu slajdów Lavender"
-#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2024 Mateusz Karcz. Udostępniono na zasadach Licencji MIT."
+#define VER_LEGALCOPYRIGHT_STR      "(C) 2021-2025 Mateusz Karcz. Udostępniono na zasadach Licencji MIT."
 #define VER_VERSION_UNICODE_LANG    "041504B0"
 #define VER_VERSION_TRANSLATION     LCID_PLK,0x04B0
 


### PR DESCRIPTION
Fixes #221 