### PR TITLE
Enlighten the DOS application on Windows 9x

### DIFF
--- a/inc/api/winoldap.h
+++ b/inc/api/winoldap.h
@@ -24,4 +24,37 @@ winoldap_set_title(far const char *title)
     return ax;
 }
 
+static inline short
+winoldap_set_closable(unsigned state)
+{
+    unsigned ax;
+    asm volatile("int $0x2F"
+                 : "=a"(ax)
+                 : "a"(0x168F), "d"(0x0000 | (state & 0xFF))
+                 : "memory", "cc");
+    return ax;
+}
+
+static inline short
+winoldap_query_close(void)
+{
+    unsigned ax;
+    asm volatile("int $0x2F"
+                 : "=a"(ax)
+                 : "a"(0x168F), "d"(0x0100)
+                 : "memory", "cc");
+    return ax;
+}
+
+static inline short
+winoldap_acknowledge_close(void)
+{
+    unsigned ax;
+    asm volatile("int $0x2F"
+                 : "=a"(ax)
+                 : "a"(0x168F), "d"(0x0200)
+                 : "memory", "cc");
+    return ax;
+}
+
 #endif // _API_WINOLDAP_H_

--- a/inc/api/winoldap.h
+++ b/inc/api/winoldap.h
@@ -1,11 +1,26 @@
 #ifndef _API_WINOLDAP_H_
 #define _API_WINOLDAP_H_
 
+#include <i86.h>
+
+#include <base.h>
+
 static inline unsigned
 winoldap_get_version(void)
 {
     unsigned ax;
     asm volatile("int $0x2F" : "=a"(ax) : "a"(0x1700) : "memory", "cc");
+    return ax;
+}
+
+static inline unsigned
+winoldap_set_title(far const char *title)
+{
+    unsigned ax;
+    asm volatile("push %%es; mov %%si, %%es; int $0x2F; pop %%es"
+                 : "=a"(ax)
+                 : "a"(0x168E), "d"(0), "D"(FP_OFF(title)), "S"(FP_SEG(title))
+                 : "memory", "cc");
     return ax;
 }
 

--- a/inc/api/winoldap.h
+++ b/inc/api/winoldap.h
@@ -1,0 +1,12 @@
+#ifndef _API_WINOLDAP_H_
+#define _API_WINOLDAP_H_
+
+static inline unsigned
+winoldap_get_version(void)
+{
+    unsigned ax;
+    asm volatile("int $0x2F" : "=a"(ax) : "a"(0x1700) : "memory", "cc");
+    return ax;
+}
+
+#endif // _API_WINOLDAP_H_

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -179,6 +179,10 @@ typedef bool (*zip_enum_files_callback)(zip_cdir_file_header *cfh, void *data);
 extern bool
 zip_open(zip_archive archive);
 
+// Close the working archive
+extern void
+zip_close(void);
+
 // Enumerate all files present in the archive
 int
 zip_enum_files(zip_enum_files_callback callback, void *data);

--- a/inc/platform/dospc.h
+++ b/inc/platform/dospc.h
@@ -15,6 +15,9 @@ typedef void interrupt far (*dospc_isr)(void);
 extern bool ddcall
 dospc_is_dosbox(void);
 
+extern bool
+dospc_is_windows(void);
+
 #ifdef CONFIG_ANDREA
 extern uint16_t
 dospc_load_driver(const char *name);

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -198,6 +198,14 @@ zip_open(zip_archive archive)
     return true;
 }
 
+void
+zip_close(void)
+{
+#ifndef ZIP_PIGGYBACK
+    close(_fd);
+#endif
+}
+
 int
 zip_enum_files(zip_enum_files_callback callback, void *data)
 {

--- a/src/gfx/dosddi.c
+++ b/src/gfx/dosddi.c
@@ -1,6 +1,7 @@
 #ifdef CONFIG_ANDREA
 #include <andrea.h>
 #endif
+#include <api/winoldap.h>
 #include <gfx.h>
 #include <pal.h>
 #include <platform/dospc.h>
@@ -144,5 +145,12 @@ gfx_cleanup(void)
 bool
 gfx_set_title(const char *title)
 {
-    return false;
+    if (!dospc_is_windows())
+    {
+        return false;
+    }
+
+    char buffer[80];
+    utf8_encode(title, buffer, pal_wctoa);
+    return 1 == winoldap_set_title(buffer);
 }

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -403,6 +403,11 @@ pal_initialize(int argc, char *argv[])
     gfx_get_glyph_dimensions(&_glyph);
     _has_mouse = msmouse_init();
 
+    if (dospc_is_windows())
+    {
+        winoldap_set_closable(1);
+    }
+
 #if defined(CONFIG_SOUND)
     snd_initialize(arg_snd);
 #endif // CONFIG_SOUND
@@ -447,6 +452,17 @@ pal_cleanup(void)
 bool
 pal_handle(void)
 {
+    if (!dospc_is_windows())
+    {
+        return true;
+    }
+
+    if (0 == winoldap_query_close())
+    {
+        winoldap_acknowledge_close();
+        return false;
+    }
+
     return true;
 }
 

--- a/src/pal/dospc.c
+++ b/src/pal/dospc.c
@@ -11,6 +11,7 @@
 #include <api/bios.h>
 #include <api/dos.h>
 #include <api/msmouse.h>
+#include <api/winoldap.h>
 #include <fmt/exe.h>
 #include <fmt/fat.h>
 #include <fmt/utf8.h>
@@ -51,6 +52,7 @@ __dospc_pit_isr(void);
 static gfx_glyph_data _font = NULL;
 static gfx_dimensions _glyph;
 static bool           _has_mouse = false;
+static short          _winoldap_version = 0;
 
 #ifdef STACK_PROFILING
 static uint64_t      *_stack_start;
@@ -852,6 +854,17 @@ bool ddcall
 dospc_is_dosbox(void)
 {
     return 0 == _fmemcmp((const char far *)0xF000E061, "DOSBox", 6);
+}
+
+bool
+dospc_is_windows(void)
+{
+    if (0 == _winoldap_version)
+    {
+        _winoldap_version = winoldap_get_version();
+    }
+
+    return 0x1700 != _winoldap_version;
 }
 
 #ifdef CONFIG_ANDREA

--- a/src/pal/ziparch.c
+++ b/src/pal/ziparch.c
@@ -100,6 +100,8 @@ ziparch_cleanup(void)
             zip_free_data(__pal_assets[i].data);
         }
     }
+
+    zip_close();
 }
 
 typedef struct


### PR DESCRIPTION
DOSPC:
- add Windows DOS box checking routine
- make application closable in Windows DOS box - closes #232 

FMT:
- close the ZIP archive after use

GFX:
- allow changing the title of Windows DOS box - closes #233 
