### PR TITLE
Add file cache and chunked asset access

### DIFF
--- a/inc/fmt/bmp.h
+++ b/inc/fmt/bmp.h
@@ -67,4 +67,7 @@ enum
 extern bool
 bmp_load_bitmap(gfx_bitmap *bm, hasset asset);
 
+extern void
+bmp_dispose_bitmap(gfx_bitmap *bm);
+
 #endif

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -172,6 +172,7 @@ typedef const char *zip_archive;
 #endif
 
 typedef off_t zip_item;
+typedef long  zip_cached;
 
 typedef bool (*zip_enum_files_callback)(zip_cdir_file_header *cfh, void *data);
 
@@ -201,6 +202,18 @@ zip_load_data(zip_item item);
 // Dispose ZIP file data
 extern void
 zip_free_data(char *data);
+
+// Cache ZIP file data
+extern zip_cached
+zip_cache(zip_item item);
+
+// Reads from cached ZIP file data
+extern void
+zip_read(zip_cached handle, char *buff, off_t at, size_t size);
+
+// Discard cached ZIP file data
+extern void
+zip_discard(zip_cached handle);
 
 // Write file data to a file
 bool

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -171,6 +171,8 @@ typedef zip_cdir_end_header *zip_archive;
 typedef const char *zip_archive;
 #endif
 
+typedef off_t zip_item;
+
 typedef bool (*zip_enum_files_callback)(zip_cdir_file_header *cfh, void *data);
 
 // Set working archive
@@ -188,13 +190,13 @@ int
 zip_enum_files(zip_enum_files_callback callback, void *data);
 
 // Locate ZIP local file header structure
-extern off_t
+extern zip_item
 zip_search(const char *name, uint16_t length);
 
 // Retrieve ZIP file data
 // Returns NULL on error
 extern char *
-zip_get_data(off_t olfh);
+zip_get_data(zip_item item);
 
 // Dispose ZIP file data
 extern void
@@ -202,11 +204,11 @@ zip_free_data(char *data);
 
 // Write file data to a file
 bool
-zip_extract_data(off_t olfh, FILE *out);
+zip_extract_data(zip_item item, FILE *out);
 
 // Get ZIP file size
 extern uint32_t
-zip_get_size(off_t olfh);
+zip_get_size(zip_item item);
 
 // Calculate ZIP-compatible CRC-32 checksum of a buffer
 // Returns checksum value

--- a/inc/fmt/zip.h
+++ b/inc/fmt/zip.h
@@ -196,7 +196,7 @@ zip_search(const char *name, uint16_t length);
 // Retrieve ZIP file data
 // Returns NULL on error
 extern char *
-zip_get_data(zip_item item);
+zip_load_data(zip_item item);
 
 // Dispose ZIP file data
 extern void

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -10,6 +10,9 @@ typedef struct
     uint16_t opl;
     uint8_t  bpp;
     void    *bits;
+    off_t    offset;
+    int16_t  chunk_top;
+    int16_t  chunk_height;
 } gfx_bitmap;
 
 typedef struct

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -8,7 +8,6 @@ typedef struct
     int16_t  width;
     int16_t  height;
     uint16_t opl;
-    uint8_t  planes;
     uint8_t  bpp;
     void    *bits;
 } gfx_bitmap;

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -130,7 +130,7 @@ extern bool
 pal_close_asset(hasset asset);
 
 extern char *
-pal_get_asset_data(hasset asset);
+pal_load_asset(hasset asset);
 
 extern long
 pal_get_asset_size(hasset asset);

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -6,6 +6,7 @@
 #include <fmt/utf8.h>
 
 DEFINE_HANDLE(hasset);
+typedef long hcache;
 
 typedef bool (*pal_enum_assets_callback)(const char *, void *);
 
@@ -134,6 +135,15 @@ pal_load_asset(hasset asset);
 
 extern long
 pal_get_asset_size(hasset asset);
+
+extern hcache
+pal_cache(int fd, off_t at, size_t size);
+
+extern void
+pal_read(hcache handle, char *buff, off_t at, size_t size);
+
+extern void
+pal_discard(hcache handle);
 
 extern const char *
 pal_get_version_string(void);

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -130,6 +130,9 @@ pal_open_asset(const char *name, int flags);
 extern bool
 pal_close_asset(hasset asset);
 
+extern bool
+pal_read_asset(hasset asset, char *buff, off_t at, size_t size);
+
 extern char *
 pal_load_asset(hasset asset);
 

--- a/src/enc/provider/remote/qr.c
+++ b/src/enc/provider/remote/qr.c
@@ -5,7 +5,7 @@
 
 #define QR_SIZE 128
 
-static gfx_bitmap _qr_bitmap = {QR_SIZE, QR_SIZE, QR_SIZE / 8, 1, 1};
+static gfx_bitmap _qr_bitmap = {QR_SIZE, QR_SIZE, QR_SIZE / 8, 1};
 
 static encui_field _qr_fields[] = {
     {ENCUIFT_BITMAP, ENCUIFF_DYNAMIC | ENCUIFF_CENTER, (intptr_t)&_qr_bitmap},

--- a/src/fmt/bmp.c
+++ b/src/fmt/bmp.c
@@ -14,7 +14,7 @@ bmp_load_bitmap(gfx_bitmap *bm, hasset asset)
 
     LOG("entry, bm: %p, asset: %p", (void *)bm, (void *)asset);
 
-    data = pal_get_asset_data(asset);
+    data = pal_load_asset(asset);
     fh = (const bmp_file_header *)data;
     if (BMP_MAGIC != fh->type)
     {

--- a/src/fmt/bmp.c
+++ b/src/fmt/bmp.c
@@ -42,9 +42,15 @@ bmp_load_bitmap(gfx_bitmap *bm, hasset asset)
 
     bm->width = ih->width;
     bm->height = -ih->height;
-    bm->planes = ih->planes;
     bm->bpp = ih->bit_count;
-    LOG("%dx%d, %u planes, %u bpp", bm->width, bm->height, bm->planes, bm->bpp);
+    LOG("%dx%d, %u bpp", bm->width, bm->height, bm->bpp);
+
+    if (1 != ih->planes)
+    {
+        LOG("exit, %d planes not supported!", ih->planes);
+        errno = EFTYPE;
+        return false;
+    }
 
     if ((1 != bm->bpp) && (4 != bm->bpp) && (32 != bm->bpp))
     {

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -344,7 +344,7 @@ _get_data(zip_item olfh, uint32_t *size, uint32_t *crc32)
 }
 
 char *
-zip_get_data(zip_item item)
+zip_load_data(zip_item item)
 {
     char    *buffer;
     uint32_t size = 0, crc32 = 0;

--- a/src/fmt/zip.c
+++ b/src/fmt/zip.c
@@ -290,7 +290,7 @@ zip_search(const char *name, uint16_t length)
 }
 
 static off_t
-_get_data(off_t olfh, uint32_t *size, uint32_t *crc32)
+_get_data(zip_item olfh, uint32_t *size, uint32_t *crc32)
 {
     zip_local_file_header *lfh;
 #ifndef ZIP_PIGGYBACK
@@ -344,11 +344,11 @@ _get_data(off_t olfh, uint32_t *size, uint32_t *crc32)
 }
 
 char *
-zip_get_data(off_t olfh)
+zip_get_data(zip_item item)
 {
     char    *buffer;
     uint32_t size = 0, crc32 = 0;
-    off_t    odata = _get_data(olfh, &size, &crc32);
+    off_t    odata = _get_data(item, &size, &crc32);
 
     if (0 > odata)
     {
@@ -394,13 +394,13 @@ zip_free_data(char *data)
 }
 
 bool
-zip_extract_data(off_t olfh, FILE *out)
+zip_extract_data(zip_item item, FILE *out)
 {
 #ifndef ZIP_PIGGYBACK
     char buffer[512];
 #endif
     uint32_t size = 0;
-    off_t    odata = _get_data(olfh, &size, NULL);
+    off_t    odata = _get_data(item, &size, NULL);
 
     if (0 > odata)
     {
@@ -442,10 +442,10 @@ zip_extract_data(off_t olfh, FILE *out)
 }
 
 uint32_t
-zip_get_size(off_t olfh)
+zip_get_size(zip_item item)
 {
     uint32_t size;
-    _get_data(olfh, &size, NULL);
+    _get_data(item, &size, NULL);
     return size;
 }
 

--- a/src/gfx/cga.c
+++ b/src/gfx/cga.c
@@ -1,6 +1,7 @@
 #include <dos.h>
 #include <graph.h>
 #include <libi86/string.h>
+#include <stdlib.h>
 
 #include <arch/dos.h>
 #include <arch/dos/bios.h>
@@ -257,14 +258,13 @@ cga_draw_bitmap(device *dev, gfx_bitmap *bm, int x, int y)
     plane1 += offset;
 
     int line_span = CGA_HIMONO_LINE;
-    int lines = bm->height;
+    int lines = bm->chunk_height ? bm->chunk_height : abs(bm->height);
     int width = (bm->width + 7) / 8;
     if (0 > bm->height)
     {
-        plane0 -= (bm->height + 1) / 2 * CGA_HIMONO_LINE;
-        plane1 -= (bm->height + 1) / 2 * CGA_HIMONO_LINE;
+        plane0 += (lines - 1) / 2 * CGA_HIMONO_LINE;
+        plane1 += (lines - 1) / 2 * CGA_HIMONO_LINE;
         line_span = -CGA_HIMONO_LINE;
-        lines = -bm->height;
     }
 
     for (uint16_t line = 0; line < lines; line += 2)

--- a/src/gfx/cga.c
+++ b/src/gfx/cga.c
@@ -240,7 +240,7 @@ cga_get_property(device *dev, gfx_property property, void *out)
 bool ddcall
 cga_draw_bitmap(device *dev, gfx_bitmap *bm, int x, int y)
 {
-    if ((1 != bm->planes) || (1 != bm->bpp))
+    if (1 != bm->bpp)
     {
         errno = EFTYPE;
         return false;

--- a/src/gfx/ega.c
+++ b/src/gfx/ega.c
@@ -1,5 +1,6 @@
 #include <conio.h>
 #include <graph.h>
+#include <stdlib.h>
 
 #include <arch/dos/bios.h>
 #include <drv.h>
@@ -110,12 +111,11 @@ ega_draw_bitmap(device *dev, gfx_bitmap *bm, int x, int y)
     far uint8_t   *fb = MK_FP(EGA_HIRES_MEM, y * EGA_HIRES_LINE + x);
 
     int line_span = EGA_HIRES_LINE;
-    int lines = bm->height;
+    int lines = bm->chunk_height ? bm->chunk_height : abs(bm->height);
     if (0 > bm->height)
     {
-        fb -= (bm->height + 1) * EGA_HIRES_LINE;
+        fb += (lines - 1) * EGA_HIRES_LINE;
         line_span = -EGA_HIRES_LINE;
-        lines = -bm->height;
     }
 
     if (1 == bm->bpp)

--- a/src/gfx/ega.c
+++ b/src/gfx/ega.c
@@ -98,12 +98,6 @@ _set_plane(unsigned i)
 bool ddcall
 ega_draw_bitmap(device *dev, gfx_bitmap *bm, int x, int y)
 {
-    if (1 != bm->planes)
-    {
-        errno = EFTYPE;
-        return false;
-    }
-
     if ((1 != bm->bpp) && (4 != bm->bpp))
     {
         errno = EFTYPE;

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -199,7 +199,7 @@ windows_create_dib(HDC dc, gfx_bitmap *bm)
     bmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi->bmiHeader.biWidth = bm->width;
     bmi->bmiHeader.biHeight = -bm->height;
-    bmi->bmiHeader.biPlanes = bm->planes;
+    bmi->bmiHeader.biPlanes = 1;
     bmi->bmiHeader.biBitCount = bm->bpp;
     bmi->bmiHeader.biCompression = BI_RGB;
 

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -197,7 +197,7 @@ windows_create_dib(HDC dc, gfx_bitmap *bm)
 
     bmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi->bmiHeader.biWidth = bm->width;
-    bmi->bmiHeader.biHeight = -bm->height;
+    bmi->bmiHeader.biHeight = bm->chunk_height ? bm->chunk_height : -bm->height;
     bmi->bmiHeader.biPlanes = 1;
     bmi->bmiHeader.biBitCount = bm->bpp;
     bmi->bmiHeader.biCompression = BI_RGB;
@@ -243,10 +243,10 @@ gfx_draw_bitmap(gfx_bitmap *bm, int x, int y)
     }
 
     width = _scale * bm->width;
-    height = _scale * abs(bm->height);
+    height = _scale * bm->chunk_height;
     SelectObject(bmp_dc, bmp);
     StretchBlt(_dc, x, y, width, height, bmp_dc, 0, 0, bm->width,
-               abs(bm->height), SRCCOPY);
+               bm->chunk_height, SRCCOPY);
 
     rect.left = x;
     rect.top = y;

--- a/src/gfx/sdl2.c
+++ b/src/gfx/sdl2.c
@@ -223,15 +223,8 @@ gfx_get_color_depth(void)
 bool
 gfx_draw_bitmap(gfx_bitmap *bm, int x, int y)
 {
-    LOG("entry, bm: %dx%d %ubpp (%u planes, %u octets per scanline), x: %u,"
-        " y: %u",
-        bm->width, bm->height, bm->bpp, bm->planes, bm->opl, x, y);
-
-    if (1 != bm->planes)
-    {
-        errno = EFTYPE;
-        return false;
-    }
+    LOG("entry, bm: %dx%d %ubpp (%u octets per scanline), x: %u, y: %u",
+        bm->width, bm->height, bm->bpp, bm->opl, x, y);
 
     if ((1 != bm->bpp) && (4 != bm->bpp) && (32 != bm->bpp))
     {

--- a/src/pal/_zip/CMakeLists.txt
+++ b/src/pal/_zip/CMakeLists.txt
@@ -1,7 +1,7 @@
 target_sources(pal PRIVATE pa-close.c)
-target_sources(pal PRIVATE pa-data.c)
 target_sources(pal PRIVATE pa-enum.c)
 target_sources(pal PRIVATE pa-extract.c)
+target_sources(pal PRIVATE pa-load.c)
 target_sources(pal PRIVATE pa-open.c)
 target_sources(pal PRIVATE pa-size.c)
 

--- a/src/pal/_zip/CMakeLists.txt
+++ b/src/pal/_zip/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(pal PRIVATE pa-enum.c)
 target_sources(pal PRIVATE pa-extract.c)
 target_sources(pal PRIVATE pa-load.c)
 target_sources(pal PRIVATE pa-open.c)
+target_sources(pal PRIVATE pa-read.c)
 target_sources(pal PRIVATE pa-size.c)
 
 target_sources(pal PRIVATE z-init.c)

--- a/src/pal/_zip/pa-close.c
+++ b/src/pal/_zip/pa-close.c
@@ -25,9 +25,15 @@ pal_close_asset(hasset asset)
 
     ptr->inzip = -1;
 
-    if (NULL != ptr->data)
+    if ((PALOPT_LOCAL == (ptr->opts & PALOPT_WHERE)) && (NULL != ptr->data))
     {
         zip_free_data(ptr->data);
+        ptr->data = NULL;
+    }
+
+    if ((PALOPT_CACHE == (ptr->opts & PALOPT_WHERE)) && (0 != ptr->handle))
+    {
+        zip_discard(ptr->handle);
         ptr->data = NULL;
     }
 

--- a/src/pal/_zip/pa-load.c
+++ b/src/pal/_zip/pa-load.c
@@ -19,7 +19,7 @@ pal_load_asset(hasset asset)
     if (NULL == ptr->data)
     {
         LOG("retrieving data for the first time");
-        ptr->data = zip_get_data(ptr->inzip);
+        ptr->data = zip_load_data(ptr->inzip);
     }
 
     LOG("exit, %p", ptr->data);

--- a/src/pal/_zip/pa-load.c
+++ b/src/pal/_zip/pa-load.c
@@ -16,6 +16,13 @@ pal_load_asset(hasset asset)
         return NULL;
     }
 
+    if (PALOPT_CACHE == (ptr->opts & PALOPT_WHERE))
+    {
+        errno = EINVAL;
+        LOG("exit, already opened in another mode");
+        return false;
+    }
+
     if (NULL == ptr->data)
     {
         LOG("retrieving data for the first time");

--- a/src/pal/_zip/pa-load.c
+++ b/src/pal/_zip/pa-load.c
@@ -3,7 +3,7 @@
 #include <assets.h>
 
 char *
-pal_get_asset_data(hasset asset)
+pal_load_asset(hasset asset)
 {
     pal_asset *ptr = (pal_asset *)asset;
 

--- a/src/pal/_zip/pa-open.c
+++ b/src/pal/_zip/pa-open.c
@@ -46,5 +46,7 @@ pal_open_asset(const char *name, int flags)
     LOG("exit, opened a new asset: %p", (void *)(pal_assets + slot));
     pal_assets[slot].inzip = lfh;
     pal_assets[slot].flags = flags;
+    pal_assets[slot].opts = 0;
+    pal_assets[slot].data = NULL;
     return (hasset)(pal_assets + slot);
 }

--- a/src/pal/_zip/pa-open.c
+++ b/src/pal/_zip/pa-open.c
@@ -43,6 +43,15 @@ pal_open_asset(const char *name, int flags)
         }
     }
 
+#if SIZE_MAX < UINT32_MAX
+    if (SIZE_MAX < zip_get_size(lfh))
+    {
+        LOG("exit, too large");
+        errno = EFBIG;
+        return NULL;
+    }
+#endif
+
     LOG("exit, opened a new asset: %p", (void *)(pal_assets + slot));
     pal_assets[slot].inzip = lfh;
     pal_assets[slot].flags = flags;

--- a/src/pal/_zip/pa-read.c
+++ b/src/pal/_zip/pa-read.c
@@ -1,0 +1,52 @@
+#include <fmt/zip.h>
+#include <pal.h>
+
+#include <assets.h>
+
+bool
+pal_read_asset(hasset asset, char *buff, off_t at, size_t size)
+{
+    pal_asset *ptr = (pal_asset *)asset;
+
+    LOG("entry, asset: %p", (void *)asset);
+
+    if (-1 == ptr->inzip)
+    {
+        LOG("exit, wrong handle");
+        errno = EBADF;
+        return false;
+    }
+
+    if (O_RDWR == (ptr->flags & O_ACCMODE))
+    {
+        errno = EINVAL;
+        LOG("exit, caching allowed for read-only");
+        return false;
+    }
+
+    if (PALOPT_LOCAL == (ptr->opts & PALOPT_WHERE))
+    {
+        errno = EINVAL;
+        LOG("exit, already opened in another mode");
+        return false;
+    }
+
+    if (0 == ptr->handle)
+    {
+        LOG("retrieving data for the first time");
+        ptr->handle = zip_cache(ptr->inzip);
+    }
+
+    if (0 >= ptr->handle)
+    {
+        ptr->handle = 0;
+        LOG("exit, failed with status %d", ptr->handle);
+        return false;
+    }
+
+    ptr->opts |= PALOPT_CACHE;
+    zip_read(ptr->handle, buff, at, size);
+
+    LOG("exit");
+    return true;
+}

--- a/src/pal/_zip/pa-size.c
+++ b/src/pal/_zip/pa-size.c
@@ -10,7 +10,7 @@ pal_get_asset_size(hasset asset)
 
     LOG("entry, asset: %p", (void *)asset);
 
-    if (-1 == ptr->inzip)
+    if ((NULL == asset) || (-1 == ptr->inzip))
     {
         LOG("exit, wrong handle");
         errno = EBADF;

--- a/src/pal/_zip/z-init.c
+++ b/src/pal/_zip/z-init.c
@@ -18,9 +18,8 @@ ziparch_initialize(zip_archive self)
 
     for (i = 0; i < MAX_OPEN_ASSETS; ++i)
     {
+        memset(pal_assets + i, 0, sizeof(pal_asset));
         pal_assets[i].inzip = -1;
-        pal_assets[i].flags = 0;
-        pal_assets[i].data = NULL;
     }
 
     if (!zip_open(self))

--- a/src/pal/dos/CMakeLists.txt
+++ b/src/pal/dos/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(pal PRIVATE ../shared/p-strings.c)
 target_sources(pal PRIVATE ../shared/p-version.c)
 
 target_sources(pal PRIVATE p-alert.c)
+target_sources(pal PRIVATE p-cache.c)
 target_sources(pal PRIVATE p-handle.c)
 target_sources(pal PRIVATE p-id.c)
 target_sources(pal PRIVATE p-init.c)

--- a/src/pal/dos/p-cache.c
+++ b/src/pal/dos/p-cache.c
@@ -1,0 +1,59 @@
+#include <dos.h>
+#include <unistd.h>
+
+#include <pal.h>
+
+hcache
+pal_cache(int fd, off_t at, size_t size)
+{
+    unsigned segment;
+    if (0 != _dos_allocmem((size + 15) >> 4, &segment))
+    {
+        return -ENOMEM;
+    }
+
+    char   buff[512];
+    size_t pos = 0;
+    lseek(fd, at, SEEK_SET);
+
+    size_t head = sizeof(buff) - (at % sizeof(buff));
+    if (head != read(fd, buff, head))
+    {
+        return -errno;
+    }
+    _fmemcpy(MK_FP(segment, pos), buff, sizeof(buff));
+    pos += head;
+
+    while (pos < size)
+    {
+        if (sizeof(buff) != read(fd, buff, sizeof(buff)))
+        {
+            return -errno;
+        }
+        _fmemcpy(MK_FP(segment, pos), buff, sizeof(buff));
+        pos += sizeof(buff);
+    }
+
+    if (pos < size)
+    {
+        if (size - pos != read(fd, buff, size - pos))
+        {
+            return -errno;
+        }
+        _fmemcpy(MK_FP(segment, pos), buff, sizeof(buff));
+    }
+
+    return segment;
+}
+
+void
+pal_discard(hcache handle)
+{
+    _dos_freemem(handle);
+}
+
+void
+pal_read(hcache handle, char *buff, off_t at, size_t size)
+{
+    _fmemcpy(buff, MK_FP(handle, at), size);
+}

--- a/src/pal/dos/p-init.c
+++ b/src/pal/dos/p-init.c
@@ -326,7 +326,7 @@ pal_initialize(int argc, char *argv[])
             msdos_exit(1);
         }
 
-        char *data = pal_get_asset_data(support);
+        char *data = pal_load_asset(support);
         if (NULL == data)
         {
             msdos_exit(1);

--- a/src/pal/inc/assets.h
+++ b/src/pal/inc/assets.h
@@ -1,13 +1,14 @@
 #ifndef _PAL_IMPL_H_
 #define _PAL_IMPL_H_
 
+#include <fmt/zip.h>
 #include <pal.h>
 
 typedef struct
 {
-    off_t inzip;
-    int   flags;
-    char *data;
+    zip_item inzip;
+    int      flags;
+    char    *data;
 } pal_asset;
 
 #ifndef O_ACCMODE

--- a/src/pal/inc/assets.h
+++ b/src/pal/inc/assets.h
@@ -8,12 +8,21 @@ typedef struct
 {
     zip_item inzip;
     int      flags;
-    char    *data;
+    int      opts;
+
+    union {
+        char      *data;
+        zip_cached handle;
+    };
 } pal_asset;
 
 #ifndef O_ACCMODE
 #define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
 #endif
+
+#define PALOPT_LOCAL 0x0001
+#define PALOPT_CACHE 0x0002
+#define PALOPT_WHERE 0x0003
 
 #define MAX_OPEN_ASSETS 8
 

--- a/src/pal/linux/CMakeLists.txt
+++ b/src/pal/linux/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(pal PRIVATE ../shared/p-strings.c)
 target_sources(pal PRIVATE ../shared/p-version.c)
 
 target_sources(pal PRIVATE p-alert.c)
+target_sources(pal PRIVATE p-cache.c)
 target_sources(pal PRIVATE p-id.c)
 target_sources(pal PRIVATE p-init.c)
 target_sources(pal PRIVATE p-shell.c)

--- a/src/pal/linux/p-cache.c
+++ b/src/pal/linux/p-cache.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <pal.h>
+
+#define MAX_CACHE 8
+
+typedef struct
+{
+    int    fd;
+    off_t  base;
+    size_t size;
+    void  *addr;
+} cache_item;
+
+static cache_item cache_[MAX_CACHE];
+
+hcache
+pal_cache(int fd, off_t at, size_t size)
+{
+    LOG("entry, fd: %d, %zu@%#lx", fd, size, (unsigned long)at);
+
+    long i = 0;
+    while ((MAX_CACHE > i) && (0 != cache_[i].fd))
+    {
+        i++;
+    }
+
+    if (MAX_CACHE == i)
+    {
+        LOG("exit, no slots");
+        return -ENOMEM;
+    }
+
+    long  page = sysconf(_SC_PAGE_SIZE);
+    off_t aligned_at = at / page * page;
+    off_t base = at % page;
+    off_t aligned_size = base + size;
+    LOG("aligned %zu@%#lx", (size_t)aligned_size, (unsigned long)aligned_at);
+
+    cache_[i].addr =
+        mmap(NULL, aligned_size, PROT_READ, MAP_PRIVATE, fd, aligned_at);
+    if (MAP_FAILED == cache_[i].addr)
+    {
+        LOG("exit, mmap failed with status %d", errno);
+        return -errno;
+    }
+
+    cache_[i].fd = fd;
+    cache_[i].base = base;
+    cache_[i].size = aligned_size;
+
+    i++;
+    LOG("exit, handle: %ld", i);
+    return i;
+}
+
+void
+pal_discard(hcache handle)
+{
+    LOG("handle: %ld", handle);
+
+    cache_item *cache = cache_ + handle - 1;
+    assert(0 == munmap(cache->addr, cache->size));
+}
+
+void
+pal_read(hcache handle, char *buff, off_t at, size_t size)
+{
+    LOG("handle: %ld, %zu@%#lx", handle, size, at);
+
+    assert((0 < handle) && (MAX_CACHE >= handle));
+    cache_item *cache = cache_ + handle - 1;
+    memcpy(buff, (char *)cache->addr + cache->base + at, size);
+}

--- a/src/pal/windows/CMakeLists.txt
+++ b/src/pal/windows/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(pal PRIVATE ../shared/p-mouse.c)
 
 target_sources(pal PRIVATE p-alert.c)
+target_sources(pal PRIVATE p-cache.c)
 target_sources(pal PRIVATE p-handle.c)
 target_sources(pal PRIVATE p-id.c)
 target_sources(pal PRIVATE p-init.c)

--- a/src/pal/windows/p-cache.c
+++ b/src/pal/windows/p-cache.c
@@ -1,0 +1,150 @@
+#include <assert.h>
+#include <io.h>
+#include <windows.h>
+
+#include <pal.h>
+
+#define MAX_CACHE_FILES 8
+#define MAX_CACHE_ITEMS 8
+
+typedef struct
+{
+    int    fd;
+    HANDLE file;
+    HANDLE mapping;
+    int    count;
+} cache_file;
+
+typedef struct
+{
+    int    fd;
+    off_t  base;
+    size_t size;
+    void  *addr;
+} cache_item;
+
+static cache_file files_[MAX_CACHE_FILES];
+static cache_item cache_[MAX_CACHE_ITEMS];
+
+static int
+acquire(int fd)
+{
+    int i = 0;
+
+    while ((MAX_CACHE_FILES > i) && (0 != files_[i].fd) && (fd != files_[i].fd))
+    {
+        i++;
+    }
+
+    if (MAX_CACHE_FILES == i)
+    {
+        return -ENOMEM;
+    }
+
+    if (files_[i].fd != fd)
+    {
+        HANDLE file = (HANDLE)_get_osfhandle(fd);
+        HANDLE mapping =
+            CreateFileMappingW(file, NULL, PAGE_READONLY, 0, 0, NULL);
+        if (NULL == mapping)
+        {
+            return (hcache)-GetLastError();
+        }
+
+        files_[i].fd = fd;
+        files_[i].file = file;
+        files_[i].mapping = mapping;
+        files_[i].count = 0;
+    }
+
+    files_[i].count++;
+    return i;
+}
+
+static void
+release(int fd)
+{
+    int i = 0;
+
+    while ((MAX_CACHE_FILES > i) && (fd != files_[i].fd))
+    {
+        i++;
+    }
+
+    if (MAX_CACHE_FILES == i)
+    {
+        return;
+    }
+
+    files_[i].count--;
+    if (0 == files_[i].count)
+    {
+        CloseHandle(files_[i].mapping);
+        memset(&files_[i], 0, sizeof(files_[i]));
+    }
+}
+
+hcache
+pal_cache(int fd, off_t at, size_t size)
+{
+    int            file, i = 0;
+    SYSTEM_INFO    info;
+    off_t          aligned_at, aligned_size, base;
+    ULARGE_INTEGER offset = {0};
+
+    while ((MAX_CACHE_ITEMS > i) && (0 != cache_[i].fd))
+    {
+        i++;
+    }
+
+    if (MAX_CACHE_ITEMS == i)
+    {
+        return -ENOMEM;
+    }
+
+    file = acquire(fd);
+    if (0 > file)
+    {
+        return file;
+    }
+
+    GetSystemInfo(&info);
+    aligned_at =
+        at / info.dwAllocationGranularity * info.dwAllocationGranularity;
+    base = at % info.dwAllocationGranularity;
+    aligned_size = base + size;
+
+    offset.QuadPart = aligned_at;
+    cache_[i].addr =
+        MapViewOfFile(files_[file].mapping, FILE_MAP_READ, offset.HighPart,
+                      offset.LowPart, aligned_size);
+    if (NULL == cache_[i].addr)
+    {
+        release(fd);
+        return (hcache)-GetLastError();
+    }
+
+    cache_[i].fd = fd;
+    cache_[i].base = base;
+    cache_[i].size = aligned_size;
+
+    i++;
+    return i;
+}
+
+void
+pal_discard(hcache handle)
+{
+    cache_item *cache = cache_ + handle - 1;
+    assert(UnmapViewOfFile(cache->addr));
+    release(cache->fd);
+    memset(cache, 0, sizeof(*cache));
+}
+
+void
+pal_read(hcache handle, char *buff, off_t at, size_t size)
+{
+    cache_item *cache = cache_ + handle - 1;
+    assert((0 < handle) && (MAX_CACHE_ITEMS >= handle));
+    memcpy(buff, (char *)cache->addr + cache->base + at, size);
+}

--- a/src/pal/windows/p-init.c
+++ b/src/pal/windows/p-init.c
@@ -202,7 +202,7 @@ pal_initialize(int argc, char *argv[])
     {
         int   small_size = GetSystemMetrics(SM_CYSMICON);
         int   large_size = GetSystemMetrics(SM_CYICON);
-        char *data = pal_get_asset_data(icon);
+        char *data = pal_load_asset(icon);
         int   size = pal_get_asset_size(icon);
 
         int small_offset = LookupIconIdFromDirectoryEx(

--- a/src/sld/bitmap.c
+++ b/src/sld/bitmap.c
@@ -39,15 +39,6 @@ _enum_assets_callback(const char *name, void *data)
         return true;
     }
 
-#if INTPTR_MAX < LONG_MAX
-    if (INTPTR_MAX < pal_get_asset_size(asset))
-    {
-        LOG("exit, too large");
-        pal_close_asset(asset);
-        return true;
-    }
-#endif
-
     if (NULL != ctx->asset)
     {
         pal_close_asset(ctx->asset);

--- a/src/sld/context.c
+++ b/src/sld/context.c
@@ -21,7 +21,7 @@ sld_create_context(const char *name, int flags)
         return NULL;
     }
 
-    ctx->data = pal_get_asset_data(ctx->script);
+    ctx->data = pal_load_asset(ctx->script);
     if (NULL == ctx->data)
     {
         pal_close_asset(ctx->script);

--- a/src/snd/snd.c
+++ b/src/snd/snd.c
@@ -212,7 +212,7 @@ snd_play(const char *name)
         return false;
     }
 
-    data = pal_get_asset_data(_music);
+    data = pal_load_asset(_music);
     if (NULL == data)
     {
         return false;


### PR DESCRIPTION
FMT/ZIP:
- add `zip_item` type
- rename `zip_get_data` to `zip_load_data`
- add chunked file access using file cache

GFX:
- remove planar bitmap handling
- GDI: remove support for unaligned bitmaps
- add chunked bitmap support

PAL:
- rename `pal_get_asset_data` to `pal_load_asset`
- DOS: use far memory as cache for read-only files
- Linux, Windows: use memory mapping as cache for read-only files
- ZIP: add chunked asset access - closes #214 
- don't open unaddressable (larger than `SIZE_MAX`) assets

SLD:
- load bitmaps in chunks - closes #244 