### PR TITLE
Properly release memory allocated for drivers under DOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,9 @@ jobs:
           sudo apt update
           sudo apt install gcc-ia16-elf libi86-ia16-elf -y
           wget -nv -P ext/ https://github.com/thecatkitty/nicetia16/releases/download/REL-20250305/nicetia16-REL-20250305-${{matrix.platform.nicetia16-arch}}.zip
-          wget -nv -P ext/ https://github.com/thecatkitty/andrea/releases/download/0.1.1/andrea-0.1.1.zip
+          wget -nv -P ext/ https://github.com/thecatkitty/andrea/releases/download/0.1.2/andrea-0.1.2.zip
           unzip ext/nicetia16-REL-20250305-${{matrix.platform.nicetia16-arch}}.zip -d ext/nicetia16-${{matrix.platform.nicetia16-arch}}
-          unzip ext/andrea-0.1.1.zip -d ext/andrea
+          unzip ext/andrea-0.1.2.zip -d ext/andrea
 
       - name: Fetch Windows (IA32) dependencies
         if: matrix.platform.target == 'windows-ia32'

--- a/src/gfx/dosddi.c
+++ b/src/gfx/dosddi.c
@@ -139,7 +139,15 @@ gfx_draw_text(const char *str, uint16_t x, uint16_t y)
 void
 gfx_cleanup(void)
 {
-    return gfx_device_close(_dev);
+    gfx_device_close(_dev);
+
+#if defined(CONFIG_ANDREA)
+    if (0 != _driver)
+    {
+        dos_unload_driver(_driver);
+        _driver = 0;
+    }
+#endif
 }
 
 bool


### PR DESCRIPTION
Fixes #259 

- unload graphics driver on cleanup
- update Andrea to 0.1.2 (release module environment block)