### PR TITLE
Use a ring buffer for music playback

### DIFF
--- a/inc/ard/version.h
+++ b/inc/ard/version.h
@@ -3,7 +3,8 @@
 
 #include <minwindef.h>
 #include <sal.h>
-#include <stdbool.h>
+
+#include <base.h>
 
 typedef enum
 {

--- a/inc/base.h
+++ b/inc/base.h
@@ -31,11 +31,15 @@
 #include <intrin.h>
 #endif
 
-#define __builtin_bswap16(x) _byteswap_ushort(x)
-#define __builtin_bswap32(x) _byteswap_ulong(x)
-#define __builtin_bswap64(x) _byteswap_uint64(x)
+#define BSWAP16(x) _byteswap_ushort(x)
+#define BSWAP32(x) _byteswap_ulong(x)
+#define BSWAP64(x) _byteswap_uint64(x)
 
 #define strcasecmp _stricmp
+#else
+#define BSWAP16(x) __builtin_bswap16(x)
+#define BSWAP32(x) __builtin_bswap32(x)
+#define BSWAP64(x) __builtin_bswap64(x)
 #endif
 
 #ifndef far

--- a/inc/fmt/iff.h
+++ b/inc/fmt/iff.h
@@ -1,7 +1,7 @@
 #ifndef _FMT_IFF_H_
 #define _FMT_IFF_H_
 
-#include <base.h>
+#include <pal.h>
 
 typedef union {
     char     c[4];
@@ -22,15 +22,17 @@ typedef enum
 
 typedef struct
 {
-    const char *data;
-    iff_mode    mode;
-    uint32_t    length;
+    iff_mode   mode;
+    hasset     asset;
+    iff_fourcc type;
+    uint32_t   length;
+    uint32_t   position;
 } iff_context;
 typedef struct
 {
-    iff_fourcc  type;
-    uint32_t    length;
-    const char *data;
+    iff_fourcc type;
+    uint32_t   length;
+    uint32_t   position;
 } iff_chunk;
 
 #define IFF_FOURCC(fourcc) {fourcc}
@@ -41,7 +43,7 @@ static const iff_fourcc IFF_FOURCC_LIST = IFF_FOURCC("LIST");
 static const iff_fourcc IFF_FOURCC_CAT = IFF_FOURCC("CAT ");
 
 extern iff_context *
-iff_open(void *data, uint16_t length);
+iff_open(hasset asset);
 
 extern bool
 iff_close(iff_context *ctx);

--- a/inc/fmt/midi.h
+++ b/inc/fmt/midi.h
@@ -2,6 +2,7 @@
 #define _FMT_MIDI_H_
 
 #include <fmt/iff.h>
+#include <snd/buf.h>
 
 typedef struct
 {
@@ -70,9 +71,9 @@ static const iff_fourcc MIDI_FOURCC_MTRK = IFF_FOURCC("MTrk");
 #define MIDI_DRUMS_CHANNEL 9
 
 extern size_t
-midi_read_event(const char *buffer, midi_event *event);
+midi_read_event(snd_buffer *buffer, midi_event *event);
 
 extern size_t
-midi_read_vlq(const char *buffer, uint32_t *vlq);
+midi_read_vlq(snd_buffer *buffer, uint32_t *vlq);
 
 #endif // _FMT_MIDI_H_

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -61,7 +61,7 @@ typedef bool (*pal_enum_assets_callback)(const char *, void *);
 #define VK_OEM_MINUS 0xBD
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || (defined(_WIN32) && defined(_DEBUG))
 
 extern void
 pal_print_log(const char *location, const char *format, ...);

--- a/inc/snd.h
+++ b/inc/snd.h
@@ -33,4 +33,10 @@ snd_play(const char *name);
 extern void
 snd_handle(void);
 
+#ifdef PAL_EXTERNAL_TICK
+// Handle passage of time
+extern void
+snd_tick(void);
+#endif
+
 #endif // _SND_H_

--- a/inc/snd.h
+++ b/inc/snd.h
@@ -33,12 +33,4 @@ snd_play(const char *name);
 extern void
 snd_handle(void);
 
-// Start MIDI sequence
-extern bool
-sndseq_start(void *music, uint16_t length);
-
-// Step MIDI sequence forward
-extern bool
-sndseq_step(void);
-
 #endif // _SND_H_

--- a/inc/snd.h
+++ b/inc/snd.h
@@ -2,23 +2,6 @@
 #define _SND_H_
 
 #include <dev.h>
-#include <fmt/midi.h>
-
-typedef struct
-{
-    bool ddcall (*open)(device *dev);
-    void ddcall (*close)(device *dev);
-    bool ddcall (*write)(device *dev, const midi_event *);
-    bool ddcall (*tick)(device *dev, uint32_t ts);
-} snd_device_ops;
-
-#define snd_device_open(dev) (((far snd_device_ops *)((dev)->ops))->open((dev)))
-#define snd_device_close(dev)                                                  \
-    (((far snd_device_ops *)((dev)->ops))->close((dev)))
-#define snd_device_write(dev, event)                                           \
-    (((far snd_device_ops *)((dev)->ops))->write((dev), (event)))
-#define snd_device_tick(dev, ts)                                               \
-    (((far snd_device_ops *)((dev)->ops))->tick((dev), (ts)))
 
 typedef bool (*snd_enum_devices_callback)(device *device, void *data);
 
@@ -30,14 +13,6 @@ snd_load_inbox_drivers(void);
 extern void
 snd_enum_devices(snd_enum_devices_callback callback, void *data);
 
-// Register a sound device
-extern int ddcall
-snd_register_device(far device *dev);
-
-// Unregister all sound devices sharing one protocol
-extern int ddcall
-snd_unregister_devices(far snd_device_ops *ops);
-
 // Initialize sound system
 extern bool
 snd_initialize(const char *arg);
@@ -46,6 +21,10 @@ snd_initialize(const char *arg);
 extern void
 snd_cleanup(void);
 
+// Get currently active device pointer
+extern device *
+snd_get_device(void);
+
 // Start playing music
 extern bool
 snd_play(const char *name);
@@ -53,10 +32,6 @@ snd_play(const char *name);
 // Handle sound related services
 extern void
 snd_handle(void);
-
-// Send MIDI message
-extern bool
-snd_send(const midi_event *event);
 
 // Start MIDI sequence
 extern bool

--- a/inc/snd/buf.h
+++ b/inc/snd/buf.h
@@ -1,0 +1,32 @@
+#ifndef _SND_BUF_H_
+#define _SND_BUF_H_
+
+#include <base.h>
+
+typedef struct
+{
+    size_t   size;
+    uint32_t position;
+    char    *data;
+    int      flags;
+} snd_buffer;
+
+#define SNDBUFF_REQPKT (1 << 0)
+#define SNDBUFF_ACKPKT (1 << 1)
+#define SNDBUFF_NOMORE (1 << 2)
+
+#define SND_PACKET_SIZE(buffer) ((buffer)->size / 2)
+
+extern bool
+sndbuf_read(snd_buffer *buffer, size_t size, char *data);
+
+extern int
+sndbuf_getc(snd_buffer* buffer);
+
+extern int
+sndbuf_peek(snd_buffer* buffer);
+
+extern char *
+sndbuf_next_packet(const snd_buffer *buffer);
+
+#endif // _SND_BUF_H_

--- a/inc/snd/dev.h
+++ b/inc/snd/dev.h
@@ -1,0 +1,30 @@
+#ifndef _SND_DEV_H_
+#define _SND_DEV_H_
+
+#include <dev.h>
+#include <fmt/midi.h>
+#include <snd.h>
+
+typedef struct
+{
+    bool ddcall (*open)(device *dev);
+    void ddcall (*close)(device *dev);
+    bool ddcall (*write)(device *dev, const midi_event *);
+    bool ddcall (*tick)(device *dev, uint32_t ts);
+} snd_device_ops;
+
+#define SND_DEVICE_OPS(dev)          ((far snd_device_ops *)((dev)->ops))
+#define snd_device_open(dev)         SND_DEVICE_OPS(dev)->open((dev))
+#define snd_device_close(dev)        SND_DEVICE_OPS(dev)->close((dev))
+#define snd_device_write(dev, event) SND_DEVICE_OPS(dev)->write((dev), (event))
+#define snd_device_tick(dev, ts)     SND_DEVICE_OPS(dev)->tick((dev), (ts))
+
+// Register a sound device
+extern int ddcall
+snd_register_device(far device *dev);
+
+// Unregister all sound devices sharing one protocol
+extern int ddcall
+snd_unregister_devices(far snd_device_ops *ops);
+
+#endif // _SND_DEV_H_

--- a/inc/snd/seq.h
+++ b/inc/snd/seq.h
@@ -1,0 +1,14 @@
+#ifndef _SND_SEQ_H_
+#define _SND_SEQ_H_
+
+#include <base.h>
+
+// Start MIDI sequence
+extern bool
+sndseq_start(void *music, uint16_t length);
+
+// Step MIDI sequence forward
+extern bool
+sndseq_step(void);
+
+#endif // _SND_SEQ_H_

--- a/inc/snd/seq.h
+++ b/inc/snd/seq.h
@@ -19,4 +19,7 @@ sndseq_start(void);
 extern bool
 sndseq_step(void);
 
+extern bool
+sndseq_feed(void);
+
 #endif // _SND_SEQ_H_

--- a/inc/snd/seq.h
+++ b/inc/snd/seq.h
@@ -3,9 +3,17 @@
 
 #include <base.h>
 
+// Open MIDI file for playback
+extern bool
+sndseq_open(const char *name);
+
+// Close MIDI file
+extern bool
+sndseq_close(void);
+
 // Start MIDI sequence
 extern bool
-sndseq_start(void *music, uint16_t length);
+sndseq_start(void);
 
 // Step MIDI sequence forward
 extern bool

--- a/src/ard/config.c
+++ b/src/ard/config.c
@@ -3,14 +3,6 @@
 #include <stdlib.h>
 #include <windows.h>
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-
-#define BSWAP32(x) _byteswap_ulong(x)
-#else
-#define BSWAP32(x) __builtin_bswap32(x)
-#endif
-
 #include <ard/config.h>
 #include <ard/version.h>
 

--- a/src/ard/version/windows.c
+++ b/src/ard/version/windows.c
@@ -3,14 +3,6 @@
 #include <stdio.h>
 #include <windows.h>
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-
-#define BSWAP16(x) _byteswap_ushort(x)
-#else
-#define BSWAP16(x) __builtin_bswap16(x)
-#endif
-
 #include <ard/version.h>
 
 typedef BOOL(WINAPI *pf_getversionex)(LPOSVERSIONINFO);

--- a/src/enc/cipher/des.c
+++ b/src/enc/cipher/des.c
@@ -40,13 +40,13 @@ _rotl28(uint32_t value, uint8_t count)
 static uint64_t
 _from_bytes(const uint8_t *block)
 {
-    return __builtin_bswap64(*(const uint64_t *)block);
+    return BSWAP64(*(const uint64_t *)block);
 }
 
 static void
 _to_bytes(uint64_t num, uint8_t *block)
 {
-    *(uint64_t *)block = __builtin_bswap64(num);
+    *(uint64_t *)block = BSWAP64(num);
 }
 
 static void

--- a/src/enc/provider/prompt.c
+++ b/src/enc/provider/prompt.c
@@ -129,8 +129,8 @@ __enc_prompt_proc(int msg, enc_context *enc)
             (ENC_KEYSM_PKEY25XOR2B == (enc->provider >> 8)))
         {
             enc_decode_key(enc->buffer, enc->key.b, enc->provider >> 8);
-            (&enc->key.qw)[0] = __builtin_bswap64((&enc->key.qw)[0]);
-            (&enc->key.qw)[1] = __builtin_bswap64((&enc->key.qw)[1]);
+            (&enc->key.qw)[0] = BSWAP64((&enc->key.qw)[0]);
+            (&enc->key.qw)[1] = BSWAP64((&enc->key.qw)[1]);
 
             return 0;
         }

--- a/src/enc/provider/remote/remote.c
+++ b/src/enc/provider/remote/remote.c
@@ -290,8 +290,8 @@ __enc_remote_proc(int msg, enc_context *enc)
     case ENCM_TRANSFORM: {
         __enc_des_expand56(_56betoull(encr_response), enc->key.b);
         __enc_des_expand56(_56betoull(encr_response + 7), enc->key.b + 8);
-        (&enc->key.qw)[0] = __builtin_bswap64((&enc->key.qw)[0]);
-        (&enc->key.qw)[1] = __builtin_bswap64((&enc->key.qw)[1]);
+        (&enc->key.qw)[0] = BSWAP64((&enc->key.qw)[0]);
+        (&enc->key.qw)[1] = BSWAP64((&enc->key.qw)[1]);
         return 0;
     }
 

--- a/src/fmt/iff.c
+++ b/src/fmt/iff.c
@@ -83,8 +83,7 @@ iff_next_chunk(iff_context *ctx, iff_chunk *it)
         uint32_t length;
 
         memcpy(&head, ctx->data + pos, sizeof(head));
-        length = (ctx->mode & IFF_MODE_BE) ? __builtin_bswap32(head.length)
-                                           : head.length;
+        length = (ctx->mode & IFF_MODE_BE) ? BSWAP32(head.length) : head.length;
 
         if ((0 == it->type.dw) || (head.type.dw == it->type.dw))
         {

--- a/src/fmt/iff.c
+++ b/src/fmt/iff.c
@@ -4,10 +4,10 @@
 #include <pal.h>
 
 iff_context *
-iff_open(void *data, uint16_t length)
+iff_open(hasset asset)
 {
     iff_context *ctx;
-    iff_head    *head;
+    iff_head     head;
 
     ctx = (iff_context *)malloc(sizeof(iff_context));
     if (NULL == ctx)
@@ -15,26 +15,28 @@ iff_open(void *data, uint16_t length)
         return NULL;
     }
 
-    ctx->data = data;
-    ctx->length = length;
+    ctx->asset = asset;
+    ctx->position = 0;
 
-    head = (iff_head *)ctx->data;
-    if (IFF_FOURCC_RIFF.dw == head->type.dw)
+    pal_read_asset(asset, (char *)&head, ctx->position, sizeof(head));
+    ctx->type.dw = head.type.dw;
+
+    if (IFF_FOURCC_RIFF.dw == head.type.dw)
     {
         ctx->mode = IFF_MODE_BE;
-        ctx->length = head->length + sizeof(iff_head);
+        ctx->length = head.length + sizeof(iff_head);
     }
-    else if ((IFF_FOURCC_FORM.dw == head->type.dw) ||
-             (IFF_FOURCC_LIST.dw == head->type.dw) ||
-             (IFF_FOURCC_CAT.dw == head->type.dw))
+    else if ((IFF_FOURCC_FORM.dw == head.type.dw) ||
+             (IFF_FOURCC_LIST.dw == head.type.dw) ||
+             (IFF_FOURCC_CAT.dw == head.type.dw))
     {
         ctx->mode = IFF_MODE_BE;
-        ctx->length = head->length + sizeof(iff_head);
+        ctx->length = head.length + sizeof(iff_head);
     }
     else
     {
         ctx->mode = IFF_MODE_BE | IFF_MODE_NOHEAD;
-        ctx->length = length;
+        ctx->length = pal_get_asset_size(asset);
     }
 
     return ctx;
@@ -58,14 +60,14 @@ iff_next_chunk(iff_context *ctx, iff_chunk *it)
 {
     ptrdiff_t pos;
 
-    if (NULL == it->data)
+    if (0 == it->position)
     {
-        it->data =
-            ctx->data + ((ctx->mode & IFF_MODE_NOHEAD) ? 0 : sizeof(iff_head));
+        it->position = ctx->position +
+                       ((ctx->mode & IFF_MODE_NOHEAD) ? 0 : sizeof(iff_head));
         it->length = 0;
     }
 
-    pos = it->data - ctx->data;
+    pos = it->position - ctx->position;
     if (0 > pos)
     {
         return false;
@@ -82,14 +84,15 @@ iff_next_chunk(iff_context *ctx, iff_chunk *it)
         iff_head head;
         uint32_t length;
 
-        memcpy(&head, ctx->data + pos, sizeof(head));
+        pal_read_asset(ctx->asset, (char *)&head, ctx->position + pos,
+                       sizeof(head));
         length = (ctx->mode & IFF_MODE_BE) ? BSWAP32(head.length) : head.length;
 
         if ((0 == it->type.dw) || (head.type.dw == it->type.dw))
         {
             it->type.dw = head.type.dw;
             it->length = length;
-            it->data = ctx->data + pos + sizeof(iff_head);
+            it->position = ctx->position + pos + sizeof(iff_head);
             return true;
         }
 

--- a/src/pal/_zip/pa-close.c
+++ b/src/pal/_zip/pa-close.c
@@ -34,7 +34,7 @@ pal_close_asset(hasset asset)
     if ((PALOPT_CACHE == (ptr->opts & PALOPT_WHERE)) && (0 != ptr->handle))
     {
         zip_discard(ptr->handle);
-        ptr->data = NULL;
+        ptr->handle = (zip_cached)0;
     }
 
     LOG("exit");

--- a/src/pal/_zip/pa-read.c
+++ b/src/pal/_zip/pa-read.c
@@ -8,7 +8,7 @@ pal_read_asset(hasset asset, char *buff, off_t at, size_t size)
 {
     pal_asset *ptr = (pal_asset *)asset;
 
-    LOG("entry, asset: %p", (void *)asset);
+    LOG("entry, asset: %p, %lu @ %lu", (void *)asset, (long)size, (long)at);
 
     if (-1 == ptr->inzip)
     {
@@ -47,6 +47,5 @@ pal_read_asset(hasset asset, char *buff, off_t at, size_t size)
     ptr->opts |= PALOPT_CACHE;
     zip_read(ptr->handle, buff, at, size);
 
-    LOG("exit");
     return true;
 }

--- a/src/pal/_zip/z-init.c
+++ b/src/pal/_zip/z-init.c
@@ -40,9 +40,16 @@ ziparch_cleanup(void)
 
     for (i = 0; i < MAX_OPEN_ASSETS; ++i)
     {
-        if (NULL != pal_assets[i].data)
+        if ((PALOPT_LOCAL == (pal_assets[i].opts & PALOPT_WHERE)) &&
+            (NULL != pal_assets[i].data))
         {
             zip_free_data(pal_assets[i].data);
+        }
+
+        if ((PALOPT_CACHE == (pal_assets[i].opts & PALOPT_WHERE)) &&
+            (0 != pal_assets[i].handle))
+        {
+            zip_discard(pal_assets[i].handle);
         }
     }
 

--- a/src/pal/windows/p-init.c
+++ b/src/pal/windows/p-init.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <stdio.h>
 
 // clang-format off
@@ -258,3 +259,20 @@ pal_cleanup(void)
     gfx_cleanup();
     ziparch_cleanup();
 }
+
+#ifdef _DEBUG
+void
+pal_print_log(const char *location, const char *format, ...)
+{
+    char msg[4096];
+    int length = sprintf(msg, "%s: ", location);
+
+    va_list args;
+    va_start(args, format);
+    vsnprintf(msg + length, lengthof(msg) - length, format, args);
+    va_end(args);
+
+    strcat(msg, "\r\n");
+    OutputDebugStringA(msg);
+}
+#endif

--- a/src/pal/windows/w-version.c
+++ b/src/pal/windows/w-version.c
@@ -5,6 +5,5 @@ static uint16_t version_ = 0;
 uint16_t
 windows_get_version(void)
 {
-    return version_ ? version_
-                    : (version_ = __builtin_bswap16(LOWORD(GetVersion())));
+    return version_ ? version_ : (version_ = BSWAP16(LOWORD(GetVersion())));
 }

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -102,7 +102,7 @@ sld_handle(void)
         return;
     }
 
-#if defined(CONFIG_SOUND) && !PAL_EXTERNAL_TICK
+#if defined(CONFIG_SOUND)
     snd_handle();
 #endif
 

--- a/src/snd/CMakeLists.txt
+++ b/src/snd/CMakeLists.txt
@@ -3,6 +3,7 @@ add_dependencies(snd config)
 
 target_sources(snd PRIVATE drivers.c)
 target_sources(snd PRIVATE snd.c)
+target_sources(snd PRIVATE buf.c)
 target_sources(snd PRIVATE seq.c)
 
 if(DOS)

--- a/src/snd/buf.c
+++ b/src/snd/buf.c
@@ -1,0 +1,87 @@
+#include <pal.h>
+#include <snd/buf.h>
+
+static bool
+request_packet(snd_buffer *buffer)
+{
+    LOG("entry at %lu", (unsigned long)buffer->position);
+
+    if (buffer->flags & SNDBUFF_NOMORE)
+    {
+        LOG("no more packets after %lu!", (unsigned long)buffer->position);
+        return true;
+    }
+
+    if ((buffer->flags & SNDBUFF_REQPKT) && !(buffer->flags & SNDBUFF_ACKPKT))
+    {
+        LOG("underrun at %lu!", (unsigned long)buffer->position);
+        return false;
+    }
+
+    buffer->flags &= ~SNDBUFF_ACKPKT;
+    buffer->flags |= SNDBUFF_REQPKT;
+    return true;
+}
+
+bool
+sndbuf_read(snd_buffer *buffer, size_t size, char *data)
+{
+    int    i;
+    size_t packet = SND_PACKET_SIZE(buffer);
+    size_t position = (size_t)(buffer->position % (uint32_t)buffer->size);
+
+    for (i = 0; i < size; i++)
+    {
+        data[i] = buffer->data[position];
+
+        position++;
+        buffer->position++;
+
+        if (packet == position)
+        {
+            if (!request_packet(buffer))
+            {
+                break;
+            }
+        }
+
+        if (buffer->size == position)
+        {
+            position = 0;
+            if (!request_packet(buffer))
+            {
+                break;
+            }
+        }
+    }
+
+    return size == i;
+}
+
+int
+sndbuf_getc(snd_buffer* buffer)
+{
+    uint8_t byte = 0;
+
+    if (!sndbuf_read(buffer, 1, (char*)&byte))
+    {
+        return -1;
+    }
+
+    return byte;
+}
+
+int
+sndbuf_peek(snd_buffer* buffer)
+{
+    size_t position = (size_t)(buffer->position % (uint32_t)buffer->size);
+    return (uint8_t)buffer->data[position];
+}
+
+extern char *
+sndbuf_next_packet(const snd_buffer *buffer)
+{
+    size_t packet = SND_PACKET_SIZE(buffer);
+    size_t position = (size_t)(buffer->position % (uint32_t)buffer->size);
+    return buffer->data + packet * (1 - position / packet);
+}

--- a/src/snd/dbeep.c
+++ b/src/snd/dbeep.c
@@ -2,6 +2,7 @@
 #include <drv.h>
 #include <pal.h>
 #include <snd.h>
+#include <snd/dev.h>
 
 #define KEY_NONE         255
 #define KEY_MIN          14 // PIT incapable of frequencies lower than D0

--- a/src/snd/dfluid.c
+++ b/src/snd/dfluid.c
@@ -111,6 +111,27 @@ fluid_close(device *dev)
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 
+static size_t
+parse_vlq(const char *buffer, uint32_t *out)
+{
+    uint32_t byte;
+    size_t   count = 0;
+
+    *out = 0;
+
+    do
+    {
+        byte = (uint8_t)*buffer;
+
+        *out <<= 7;
+        *out |= byte & 0x7F;
+
+        count++;
+    } while (byte & 0x80);
+
+    return count;
+}
+
 static bool ddcall
 fluid_write(device *dev, const midi_event *event)
 {
@@ -321,7 +342,7 @@ fluid_write(device *dev, const midi_event *event)
         LOG("COM %-10.10s %3d", "MetaEvent", type);
 
         uint32_t    data_len;
-        const char *data = msg + 1 + midi_read_vlq(msg + 1, &data_len);
+        const char *data = msg + 1 + parse_vlq(msg + 1, &data_len);
 
         if ((MIDI_META_TEXT <= type) && (MIDI_META_CUEPOINT >= type))
         {

--- a/src/snd/dfluid.c
+++ b/src/snd/dfluid.c
@@ -3,7 +3,7 @@
 
 #include <arch/linux.h>
 #include <pal.h>
-#include <snd.h>
+#include <snd/dev.h>
 
 static const char *SOUNDFONTS[] = {"/usr/share/sounds/sf2/default-GM.sf2",
                                    "/usr/share/soundfonts/default-GM.sf2",

--- a/src/snd/dmme.c
+++ b/src/snd/dmme.c
@@ -13,7 +13,7 @@ static UINT     _timer = 0;
 static void CALLBACK
 _time_callback(UINT id, UINT msg, DWORD_PTR user, DWORD_PTR dw1, DWORD_PTR dw2)
 {
-    snd_handle();
+    snd_tick();
 }
 #endif
 

--- a/src/snd/dmme.c
+++ b/src/snd/dmme.c
@@ -2,7 +2,7 @@
 #include <windows.h>
 
 #include <pal.h>
-#include <snd.h>
+#include <snd/dev.h>
 
 static HMIDIOUT _out = NULL;
 

--- a/src/snd/dmpu401.c
+++ b/src/snd/dmpu401.c
@@ -3,7 +3,7 @@
 
 #include <drv.h>
 #include <pal.h>
-#include <snd.h>
+#include <snd/dev.h>
 
 #define MPU401_DATA    0x330
 #define MPU401_CONTROL 0x331

--- a/src/snd/dopl2.c
+++ b/src/snd/dopl2.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 #include <pal.h>
-#include <snd.h>
+#include <snd/dev.h>
 
 #include "opl2.h"
 

--- a/src/snd/seq.c
+++ b/src/snd/seq.c
@@ -9,7 +9,7 @@ static device      *_dev = NULL;
 static hasset       _asset = NULL;
 static iff_context *_iff = 0;
 static uint16_t     _division = 960;
-static const char  *_track = 0, *_track_end;
+static char        *_track = 0, *_track_cur, *_track_end;
 static midi_event   _event = {0, 0, NULL, 0};
 
 static uint32_t _kilotick_rate;
@@ -18,7 +18,6 @@ static uint32_t _next_event;
 bool
 sndseq_open(const char *name)
 {
-    char  *data;
     hasset asset;
 
     if (_asset)
@@ -30,12 +29,6 @@ sndseq_open(const char *name)
 
     asset = pal_open_asset(name, O_RDONLY);
     if (NULL == asset)
-    {
-        return false;
-    }
-
-    data = pal_load_asset(asset);
-    if (NULL == data)
     {
         return false;
     }
@@ -60,29 +53,19 @@ sndseq_close(void)
 bool
 sndseq_start(void)
 {
-    midi_mthd mthd = {0};
     iff_chunk mtrk_chunk = {0};
     iff_chunk it = {0};
-    iff_head *head;
 
-    void *music = pal_load_asset(_asset);
-    long  length = pal_get_asset_size(_asset);
-
-    if (NULL == music)
-    {
-        return false;
-    }
-
-    head = (iff_head *)music;
-    if (MIDI_FOURCC_MTHD.dw != head->type.dw)
-    {
-        errno = EFTYPE;
-        return false;
-    }
-
-    _iff = iff_open(music, length);
+    _iff = iff_open(_asset);
     if (NULL == _iff)
     {
+        return false;
+    }
+
+    if (MIDI_FOURCC_MTHD.dw != _iff->type.dw)
+    {
+        iff_close(_iff);
+        errno = EFTYPE;
         return false;
     }
 
@@ -90,11 +73,12 @@ sndseq_start(void)
     {
         if (MIDI_FOURCC_MTHD.dw == it.type.dw)
         {
-            midi_mthd *data = (midi_mthd *)it.data;
-
-            mthd.format = BSWAP16(data->format);
-            mthd.ntrks = BSWAP16(data->ntrks);
-            mthd.division = BSWAP16(data->division);
+            midi_mthd mthd;
+            pal_read_asset(_iff->asset, (char *)&mthd, it.position,
+                           sizeof(mthd));
+            mthd.format = BSWAP16(mthd.format);
+            mthd.ntrks = BSWAP16(mthd.ntrks);
+            mthd.division = BSWAP16(mthd.division);
             if (mthd.division & MIDI_MTHD_DIVISION_SMPTE_FLAG)
             {
                 // SMPTE timing not supported
@@ -110,13 +94,13 @@ sndseq_start(void)
         {
             mtrk_chunk.type = it.type;
             mtrk_chunk.length = it.length;
-            mtrk_chunk.data = it.data;
+            mtrk_chunk.position = it.position;
         }
 
         it.type.dw = 0;
     }
 
-    if (NULL == mtrk_chunk.data)
+    if (0 == mtrk_chunk.position)
     {
         // No tracks
         iff_close(_iff);
@@ -124,7 +108,9 @@ sndseq_start(void)
         return false;
     }
 
-    _track = mtrk_chunk.data;
+    _track = (char *)malloc(mtrk_chunk.length);
+    pal_read_asset(_iff->asset, _track, mtrk_chunk.position, mtrk_chunk.length);
+    _track_cur = _track;
     _track_end = _track + mtrk_chunk.length;
     _next_event = 0;
     _dev = snd_get_device();
@@ -144,9 +130,11 @@ sndseq_step(void)
         return false;
     }
 
-    if (_track_end <= _track)
+    if (_track_end <= _track_cur)
     {
+        char *track = _track;
         _track = NULL;
+        free(track);
         iff_close(_iff);
         return true;
     }
@@ -162,10 +150,10 @@ sndseq_step(void)
         snd_device_write(_dev, &_event);
     }
 
-    length = midi_read_event(_track, &_event);
-    _track += length;
+    length = midi_read_event(_track_cur, &_event);
+    _track_cur += length;
 
-    while ((0 != length) && (0 == _event.delta) && (_track_end > _track))
+    while ((0 != length) && (0 == _event.delta) && (_track_end > _track_cur))
     {
         if ((MIDI_MSG_META == (uint8_t)_event.status) && (NULL != _event.msg) &&
             (MIDI_META_TEMPO == (uint8_t)_event.msg[0]) &&
@@ -180,13 +168,15 @@ sndseq_step(void)
         }
 
         snd_device_write(_dev, &_event);
-        length = midi_read_event(_track, &_event);
-        _track += length;
+        length = midi_read_event(_track_cur, &_event);
+        _track_cur += length;
     }
 
     if (0 == length)
     {
+        char *track = _track;
         _track = NULL;
+        free(track);
         iff_close(_iff);
         errno = EINVAL;
         return false;

--- a/src/snd/seq.c
+++ b/src/snd/seq.c
@@ -92,9 +92,9 @@ sndseq_start(void)
         {
             midi_mthd *data = (midi_mthd *)it.data;
 
-            mthd.format = __builtin_bswap16(data->format);
-            mthd.ntrks = __builtin_bswap16(data->ntrks);
-            mthd.division = __builtin_bswap16(data->division);
+            mthd.format = BSWAP16(data->format);
+            mthd.ntrks = BSWAP16(data->ntrks);
+            mthd.division = BSWAP16(data->division);
             if (mthd.division & MIDI_MTHD_DIVISION_SMPTE_FLAG)
             {
                 // SMPTE timing not supported

--- a/src/snd/seq.c
+++ b/src/snd/seq.c
@@ -1,8 +1,10 @@
 #include <pal.h>
 #include <snd.h>
+#include <snd/dev.h>
 
 #define INIT_USEC_PER_QUARTER 500000
 
+static device      *_dev = NULL;
 static iff_context *_iff = 0;
 static uint16_t     _division = 960;
 static const char  *_track = 0, *_track_end;
@@ -72,6 +74,7 @@ sndseq_start(void *music, uint16_t length)
     _track = mtrk_chunk.data;
     _track_end = _track + mtrk_chunk.length;
     _next_event = 0;
+    _dev = snd_get_device();
 
     return true;
 }
@@ -103,7 +106,7 @@ sndseq_step(void)
 
     if (NULL != _event.msg)
     {
-        snd_send(&_event);
+        snd_device_write(_dev, &_event);
     }
 
     length = midi_read_event(_track, &_event);
@@ -123,7 +126,7 @@ sndseq_step(void)
             _kilotick_rate = pal_get_ticks(usec_per_quarter / _division);
         }
 
-        snd_send(&_event);
+        snd_device_write(_dev, &_event);
         length = midi_read_event(_track, &_event);
         _track += length;
     }

--- a/src/snd/seq.c
+++ b/src/snd/seq.c
@@ -1,6 +1,7 @@
 #include <pal.h>
 #include <snd.h>
 #include <snd/dev.h>
+#include <snd/seq.h>
 
 #define INIT_USEC_PER_QUARTER 500000
 

--- a/src/snd/snd.c
+++ b/src/snd/snd.c
@@ -9,6 +9,7 @@
 
 #include <pal.h>
 #include <snd.h>
+#include <snd/dev.h>
 
 #define MAX_DEVICES 4
 
@@ -159,15 +160,10 @@ snd_cleanup(void)
 #endif // CONFIG_ANDREA
 }
 
-bool
-snd_send(const midi_event *event)
+device *
+snd_get_device(void)
 {
-    if (NULL == _device)
-    {
-        return false;
-    }
-
-    return snd_device_write(_device, event);
+    return _device;
 }
 
 void
@@ -184,7 +180,7 @@ snd_handle(void)
         _music = NULL;
     }
 
-    if (NULL != ((far snd_device_ops *)_device->ops)->tick)
+    if (NULL != SND_DEVICE_OPS(_device)->tick)
     {
         uint32_t ts = pal_get_counter();
         if (_ts != ts)

--- a/src/snd/snd.c
+++ b/src/snd/snd.c
@@ -168,7 +168,7 @@ snd_get_device(void)
 }
 
 void
-snd_handle(void)
+snd_tick(void)
 {
     if ((NULL == _device) || !_playing)
     {
@@ -190,6 +190,19 @@ snd_handle(void)
             snd_device_tick(_device, ts);
         }
     }
+}
+
+void
+snd_handle(void)
+{
+    if ((NULL == _device) || !_playing)
+    {
+        return;
+    }
+
+#if !PAL_EXTERNAL_TICK
+    snd_tick();
+#endif
 }
 
 bool

--- a/src/snd/snd.c
+++ b/src/snd/snd.c
@@ -9,6 +9,7 @@
 
 #include <pal.h>
 #include <snd.h>
+#include <snd/buf.h>
 #include <snd/dev.h>
 #include <snd/seq.h>
 
@@ -203,6 +204,12 @@ snd_handle(void)
 #if !PAL_EXTERNAL_TICK
     snd_tick();
 #endif
+
+    if (!sndseq_feed())
+    {
+        _playing = false;
+        sndseq_close();
+    }
 }
 
 bool

--- a/src/snd/snd.c
+++ b/src/snd/snd.c
@@ -10,6 +10,7 @@
 #include <pal.h>
 #include <snd.h>
 #include <snd/dev.h>
+#include <snd/seq.h>
 
 #define MAX_DEVICES 4
 


### PR DESCRIPTION
Closes #245 

FMT:
- IFF: work with asset handles instead of memory buffers

PAL:
- ZIP: cleanup cached assets
- ZIP: log cached read position and size

Repo:
- unify byte swap macros

SND:
- privatize device interface
- privatize sequencer interface
- move asset access to the sequencer
- extract tick from handle
- add ring buffer and use it for playback
- parse VLQs in the FluidSynth driver

Windows:
- add debug logs