### PR TITLE
Fix alert message encoding under Windows

### DIFF
--- a/src/pal/windows/p-alert.c
+++ b/src/pal/windows/p-alert.c
@@ -9,17 +9,17 @@ void
 pal_alert(const char *text, int error)
 {
     WCHAR msg[MAX_PATH];
+    MultiByteToWideChar(CP_UTF8, 0, text, -1, msg, MAX_PATH);
+
     if (error)
     {
-        swprintf(msg,
+        WCHAR error_msg[32];
+        swprintf(error_msg,
 #if !defined(_MSC_VER) || (_MSC_VER > 1400)
-                 MAX_PATH,
+                 lengthof(error_msg),
 #endif
-                 L"" FMT_AS L"\nerror %d", text, error);
-    }
-    else
-    {
-        MultiByteToWideChar(CP_UTF8, 0, text, -1, msg, MAX_PATH);
+                 L"\nerror %d", error);
+        wcsncat(msg, error_msg, MAX_PATH - wcslen(msg));
     }
 
     MessageBoxW(windows_wnd, msg, L"Lavender",


### PR DESCRIPTION
Don't use narrow-to-wide printf