### PR TITLE
Add locale fallback setter

### DIFF
--- a/docs/slides.md
+++ b/docs/slides.md
@@ -82,6 +82,9 @@ Loads value of `<name>` into the *Accumulator*.
 Updates `<name>` variable using the `<value>`.
 
 ### Defined variables
+* env.lang (W, except Windows) - set locale fallback
+  * 0 - error
+  * 1 - success
 * env.tz (W, DOS only) - set timezone fallback (POSIX TZ format)
   * 0 - error
   * 1 - success

--- a/src/sld/query.c
+++ b/src/sld/query.c
@@ -19,6 +19,13 @@ _get(const char *name)
 static uint16_t
 _set(const char *name, const char *value)
 {
+#if !defined(_WIN32)
+    if (0 == strcmp("env.lang", name))
+    {
+        return (0 == setenv("LANG", value, 0)) ? 1 : 0;
+    }
+#endif
+
 #if defined(__ia16__)
     if (0 == strcmp("env.tz", name))
     {


### PR DESCRIPTION
Add default locale fallback setter support to queries in scripts under DOS and Linux.

Closes #283 