### PR TITLE
pal: windows: handle music within WndProc

### DIFF
--- a/src/pal/windows/wndproc.c
+++ b/src/pal/windows/wndproc.c
@@ -5,6 +5,7 @@
 
 #include <arch/windows.h>
 #include <pal.h>
+#include <snd.h>
 
 #include "../../resource.h"
 #include "impl.h"
@@ -407,6 +408,14 @@ windows_wndproc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         paint(wnd);
         return 0;
     }
+
+#if PAL_EXTERNAL_TICK
+    case WM_TIMER: {
+        // Prevents music hang during modal UI
+        snd_handle();
+        return 0;
+    }
+#endif
     }
     return DefWindowProc(wnd, msg, wparam, lparam);
 }

--- a/src/sld/runner.c
+++ b/src/sld/runner.c
@@ -111,7 +111,7 @@ sld_handle(void)
         return;
     }
 
-#if defined(CONFIG_SOUND)
+#if defined(CONFIG_SOUND) && !PAL_EXTERNAL_TICK
     snd_handle();
 #endif
 


### PR DESCRIPTION
Fixes #284 

Windows:
- move `snd_handle` call from the main loop to the `WM_TIMER` handler