### PR TITLE
Use relative paths in ARD

### DIFF
--- a/docs/lard.md
+++ b/docs/lard.md
@@ -22,10 +22,10 @@ If some setting is not defined for a particular language, the utility falls back
 
 ```ini
 [lard]
-name         = The Application Name   ; used in title and messages, defaults to Lavender
-run          = path\to\ia32\sshow.exe ; defaults to ia32\sshow.exe
-rundos       = path\to\dos\sshow.exe  ; optional
-copyright    = (C) 2025 Foo Inc.      ; defaults to the Lavender copyright
+name         = The Application Name     ; used in title and messages, defaults to Lavender
+run          = .\path\to\ia32\sshow.exe ; defaults to .\ia32\sshow.exe
+rundos       = .\path\to\dos\sshow.exe  ; optional
+copyright    = (C) 2025 Foo Inc.        ; defaults to the Lavender copyright
 
 [colors] ; text colors, default to white 
 intro        = #0055AA ; introduction

--- a/src/ard/config.c
+++ b/src/ard/config.c
@@ -325,6 +325,9 @@ ardc_load(void)
     DWORD deps_size;
 
     ZeroMemory(&config_, sizeof(config_));
+    ZeroMemory(&global_ini_, sizeof(global_ini_));
+    ZeroMemory(&local_ini_, sizeof(local_ini_));
+    ZeroMemory(&root_, sizeof(root_));
 
     // [lard]
     LOAD_STRING(SEC_LARD, name, IDS_DEFNAME);

--- a/src/ard/resource/_neutral.rc
+++ b/src/ard/resource/_neutral.rc
@@ -4,7 +4,7 @@ STRINGTABLE
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 {
     IDS_DEFNAME, "Lavender"
-    IDS_DEFRUN, "ia32\\sshow.exe"
+    IDS_DEFRUN, ".\\ia32\\sshow.exe"
     IDS_DEFRUNDOS, ""
     IDS_DEFCPU, "i486"
 }


### PR DESCRIPTION
ARD:
- use the relative executable path by default - Fixes #288
- clear INI file path buffers (needed for Windows NT 3.x)