### PR TITLE
Unify scaling control

### DIFF
--- a/inc/arch/dos/bios.h
+++ b/inc/arch/dos/bios.h
@@ -46,6 +46,14 @@ bios_check_keystroke(void)
     return ax;
 }
 
+static inline uint8_t
+bios_get_shift_flags(void)
+{
+    uint16_t ax;
+    asm volatile("int $0x16" : "=a"(ax) : "Rah"((uint8_t)0x02));
+    return ax & 0xFF;
+}
+
 static inline void
 bios_set_cursor_position(uint8_t page, uint16_t position)
 {

--- a/inc/arch/windows.h
+++ b/inc/arch/windows.h
@@ -22,6 +22,9 @@ windows_set_font(HFONT font);
 extern bool
 windows_set_scale(float scale);
 
+extern bool
+windows_step_scale(int direction);
+
 extern void
 windows_set_box(int width, int height);
 

--- a/inc/gfx.h
+++ b/inc/gfx.h
@@ -145,6 +145,10 @@ gfx_get_pixel_aspect(void);
 // Get display scaling factor
 extern float
 gfx_get_scale(void);
+
+// Change display scaling factor by direction (-1 for smaller, +1 for larger)
+extern bool
+gfx_step_scale(int direction);
 #endif
 
 #if defined(CONFIG_HAVE_GFX_CHARSET)

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -53,6 +53,7 @@ typedef bool (*pal_enum_assets_callback)(const char *, void *);
 #define VK_F10       0x79
 #define VK_F11       0x7A
 #define VK_F12       0x7B
+#define VK_OEM_PLUS  0xBB
 #define VK_OEM_MINUS 0xBD
 #endif
 

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -57,6 +57,8 @@ typedef bool (*pal_enum_assets_callback)(const char *, void *);
 #define VK_OEM_MINUS 0xBD
 #endif
 
+#define VKMOD_CTRL (1 << 8)
+
 #if defined(CONFIG_LOGS)
 
 extern void

--- a/src/gfx/gdi.c
+++ b/src/gfx/gdi.c
@@ -157,6 +157,12 @@ gfx_get_scale(void)
     return _scale;
 }
 
+bool
+gfx_step_scale(int direction)
+{
+    return windows_step_scale(direction);
+}
+
 unsigned
 gfx_get_color_depth(void)
 {

--- a/src/gfx/sdl2.c
+++ b/src/gfx/sdl2.c
@@ -214,6 +214,12 @@ gfx_get_scale(void)
     return _scale;
 }
 
+bool
+gfx_step_scale(int direction)
+{
+    return sdl2_set_scale(_scale + (direction > 0 ? 1 : -1));
+}
+
 unsigned
 gfx_get_color_depth(void)
 {

--- a/src/pal/_sdl2/impl.h
+++ b/src/pal/_sdl2/impl.h
@@ -7,7 +7,7 @@
 
 extern gfx_dimensions sdl2_cell;
 extern const char    *sdl2_font;
-extern SDL_Keycode    sdl2_keycode;
+extern SDL_Keysym     sdl2_keysym;
 extern SDL_Renderer  *sdl2_renderer;
 
 #endif // _PAL_SDL2_IMPL_H_

--- a/src/pal/_sdl2/p-handle.c
+++ b/src/pal/_sdl2/p-handle.c
@@ -51,13 +51,13 @@ pal_handle(void)
             }
         }
 
-        sdl2_keycode = e.key.keysym.sym;
+        memcpy(&sdl2_keysym, &e.key.keysym, sizeof(sdl2_keysym));
         break;
     }
 
     case SDL_KEYUP:
         LOG("key '%s' up", SDL_GetKeyName(e.key.keysym.sym));
-        sdl2_keycode = 0;
+        memset(&sdl2_keysym, 0, sizeof(sdl2_keysym));
         break;
 
     case SDL_MOUSEMOTION: {

--- a/src/pal/_sdl2/p-handle.c
+++ b/src/pal/_sdl2/p-handle.c
@@ -37,7 +37,7 @@ pal_handle(void)
             if ((SDLK_PLUS == e.key.keysym.sym) ||
                 (SDLK_KP_PLUS == e.key.keysym.sym))
             {
-                sdl2_set_scale(gfx_get_scale() + 1);
+                gfx_step_scale(+1);
                 gfx_get_glyph_dimensions(&sdl2_cell);
                 break;
             }
@@ -45,7 +45,7 @@ pal_handle(void)
             if ((SDLK_MINUS == e.key.keysym.sym) ||
                 (SDLK_KP_MINUS == e.key.keysym.sym))
             {
-                sdl2_set_scale(gfx_get_scale() - 1);
+                gfx_step_scale(-1);
                 gfx_get_glyph_dimensions(&sdl2_cell);
                 break;
             }

--- a/src/pal/_sdl2/p-keyboard.c
+++ b/src/pal/_sdl2/p-keyboard.c
@@ -123,6 +123,11 @@ pal_get_keystroke(void)
         }
     }
 
+    if (c && (keysym.mod & KMOD_CTRL))
+    {
+        c |= VKMOD_CTRL;
+    }
+
     LOG("keystroke: %d", c);
     return c;
 }

--- a/src/pal/_sdl2/p-keyboard.c
+++ b/src/pal/_sdl2/p-keyboard.c
@@ -2,19 +2,21 @@
 
 #include "impl.h"
 
-SDL_Keycode sdl2_keycode;
+SDL_Keysym sdl2_keysym;
 
 uint16_t
 pal_get_keystroke(void)
 {
-    if (!sdl2_keycode)
+    if (!sdl2_keysym.sym)
     {
         return 0;
     }
 
-    int c = sdl2_keycode;
-    sdl2_keycode = 0;
+    SDL_Keysym keysym;
+    memcpy(&keysym, &sdl2_keysym, sizeof(keysym));
+    memset(&sdl2_keysym, 0, sizeof(sdl2_keysym));
 
+    int c = keysym.sym;
     switch (c)
     {
     case '-':
@@ -116,6 +118,6 @@ pal_get_keystroke(void)
         }
     }
 
-    LOG("keystroke: %#.2x", c);
+    LOG("keystroke: %d", c);
     return c;
 }

--- a/src/pal/_sdl2/p-keyboard.c
+++ b/src/pal/_sdl2/p-keyboard.c
@@ -19,7 +19,12 @@ pal_get_keystroke(void)
     int c = keysym.sym;
     switch (c)
     {
-    case '-':
+    case SDLK_PLUS:
+    case SDLK_KP_PLUS:
+        c = VK_OEM_PLUS;
+        break;
+    case SDLK_MINUS:
+    case SDLK_KP_MINUS:
         c = VK_OEM_MINUS;
         break;
     case SDLK_DELETE:

--- a/src/pal/dos/p-keyboard.c
+++ b/src/pal/dos/p-keyboard.c
@@ -14,6 +14,11 @@ pal_get_keystroke(void)
     uint16_t keystroke = bios_get_keystroke();
     if (keystroke & 0xFF)
     {
+        if ('+' == (keystroke & 0xFF))
+        {
+            return VK_OEM_PLUS;
+        }
+
         if ('-' == (keystroke & 0xFF))
         {
             return VK_OEM_MINUS;

--- a/src/pal/dos/p-keyboard.c
+++ b/src/pal/dos/p-keyboard.c
@@ -3,15 +3,9 @@
 #include <arch/dos/bios.h>
 #include <pal.h>
 
-uint16_t
-pal_get_keystroke(void)
+static uint16_t
+map_keystroke(uint16_t keystroke)
 {
-    if (0 == bios_check_keystroke())
-    {
-        return 0;
-    }
-
-    uint16_t keystroke = bios_get_keystroke();
     if (keystroke & 0xFF)
     {
         if ('+' == (keystroke & 0xFF))
@@ -76,4 +70,23 @@ pal_get_keystroke(void)
     default:
         return 0;
     }
+}
+
+uint16_t
+pal_get_keystroke(void)
+{
+    if (0 == bios_check_keystroke())
+    {
+        return 0;
+    }
+
+    uint16_t bios_key = bios_get_keystroke();
+    uint16_t mapped_key = map_keystroke(bios_key);
+
+    if (mapped_key && ((1 << 2) & bios_get_shift_flags()))
+    {
+        mapped_key |= VKMOD_CTRL;
+    }
+
+    return mapped_key;
 }

--- a/src/pal/windows/wndproc.c
+++ b/src/pal/windows/wndproc.c
@@ -258,7 +258,15 @@ key_down(HWND wnd, WPARAM wparam)
         {
             gfx_step_scale(
                 ((VK_OEM_PLUS == wparam) || (VK_ADD == wparam)) ? +1 : -1);
-            break;
+        }
+
+        if (VK_ADD == wparam)
+        {
+            wparam = VK_OEM_PLUS;
+        }
+        else if (VK_SUBTRACT == wparam)
+        {
+            wparam = VK_OEM_MINUS;
         }
 
         // Fall through

--- a/src/pal/windows/wndproc.c
+++ b/src/pal/windows/wndproc.c
@@ -79,6 +79,13 @@ select_scale(int idx)
     return true;
 }
 
+bool
+windows_step_scale(int direction)
+{
+    int scale_idx = match_scale(gfx_get_scale(), direction);
+    return select_scale(scale_idx);
+}
+
 static bool
 get_fullscreen_rect(HWND wnd, RECT *rect)
 {
@@ -249,10 +256,8 @@ key_down(HWND wnd, WPARAM wparam)
     case VK_SUBTRACT: {
         if (0x8000 & GetKeyState(VK_CONTROL))
         {
-            int scale_idx = match_scale(
-                gfx_get_scale(),
+            gfx_step_scale(
                 ((VK_OEM_PLUS == wparam) || (VK_ADD == wparam)) ? +1 : -1);
-            select_scale(scale_idx);
             break;
         }
 

--- a/src/pal/windows/wndproc.c
+++ b/src/pal/windows/wndproc.c
@@ -316,6 +316,11 @@ key_down(HWND wnd, WPARAM wparam)
         break;
     }
     }
+
+    if (windows_keycode && (0x8000 & GetKeyState(VK_CONTROL)))
+    {
+        windows_keycode |= VKMOD_CTRL;
+    }
 }
 
 static void


### PR DESCRIPTION
GFX:
- Add scale stepping routine

PAL:
- SDL2: Preserve full key information
- Map plus key
- Save control key state

SLD:
- Move scale control handling out of PAL - Fixes #302 